### PR TITLE
Add support for Bundle, Claim, ClaimResponse.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build
 .classpath
 .settings/
 bin
+
+# Ignore Database files
+database.mv.db
+database.trace.db

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ gradle run
 
 Access the microservice:
 ```
-curl
+curl http://localhost:9000/fhir/metadata
+curl http://localhost:9000/fhir/Bundle
+curl http://localhost:9000/fhir/Claim
+curl http://localhost:9000/fhir/ClaimResponse
 ```
 
 Submit a prior authorization request:

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:3.7.0'
   implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:3.7.0'
   implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:3.7.0'
+  implementation 'com.h2database:h2:1.4.199'
 
   // Use JUnit test framework
   testImplementation 'junit:junit:4.12'

--- a/src/main/java/org/hl7/davinci/priorauth/App.java
+++ b/src/main/java/org/hl7/davinci/priorauth/App.java
@@ -1,6 +1,7 @@
 package org.hl7.davinci.priorauth;
 
 import org.apache.meecrowave.Meecrowave;
+
 import ca.uhn.fhir.context.FhirContext;
 
 /**
@@ -15,6 +16,11 @@ public class App {
    * per-application, not per-record.
    */
   public static final FhirContext FHIR_CTX = FhirContext.forR4();
+
+  /**
+   * Local database for FHIR resources.
+   */
+  public static final Database DB = new Database();
 
   /**
    * Launch the Prior Authorization microservice.

--- a/src/main/java/org/hl7/davinci/priorauth/BundleEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/BundleEndpoint.java
@@ -1,0 +1,51 @@
+package org.hl7.davinci.priorauth;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import org.hl7.fhir.r4.model.Bundle;
+
+/**
+ * The Bundle endpoint to READ and SEARCH for submitted Bundles.
+ */
+@RequestScoped
+@Path("Bundle")
+public class BundleEndpoint {
+
+  @Context
+  private UriInfo uri;
+  
+  @GET
+  public Response searchBundles() {
+    App.DB.setBaseUrl(uri.getBaseUri());
+    Bundle bundles = App.DB.search(Database.BUNDLE);
+    String json = App.DB.json(bundles);
+    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+  
+  @GET
+  @Path("/{id}")
+  public Response readBundle(@PathParam("id") String id) {
+    String json = null;
+    if (id == null) {
+      // Search
+      Bundle bundles = App.DB.search(Database.BUNDLE);
+      json = App.DB.json(bundles);
+    } else {
+      // Read
+      Bundle bundle = (Bundle) App.DB.read(Database.BUNDLE, id);
+      if (bundle == null) {
+        return Response.status(Status.NOT_FOUND).build();
+      }
+      json = App.DB.json(bundle);
+    }
+    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -1,0 +1,52 @@
+package org.hl7.davinci.priorauth;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Claim;
+
+/**
+ * The Claim endpoint to READ and SEARCH for submitted claims.
+ */
+@RequestScoped
+@Path("Claim")
+public class ClaimEndpoint {
+
+  @Context
+  private UriInfo uri;
+  
+  @GET
+  public Response searchClaims() {
+    App.DB.setBaseUrl(uri.getBaseUri());
+    Bundle claims = App.DB.search(Database.CLAIM);
+    String json = App.DB.json(claims);
+    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+  
+  @GET
+  @Path("/{id}")
+  public Response readClaim(@PathParam("id") String id) {
+    String json = null;
+    if (id == null) {
+      // Search
+      Bundle claims = App.DB.search(Database.CLAIM);
+      json = App.DB.json(claims);
+    } else {
+      // Read
+      Claim claim = (Claim) App.DB.read(Database.CLAIM, id);
+      if (claim == null) {
+        return Response.status(Status.NOT_FOUND).build();
+      }
+      json = App.DB.json(claim);
+    }
+    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimResponseEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimResponseEndpoint.java
@@ -1,0 +1,52 @@
+package org.hl7.davinci.priorauth;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ClaimResponse;
+
+/**
+ * The ClaimResponse endpoint to READ and SEARCH for ClaimResponses to submitted claims.
+ */
+@RequestScoped
+@Path("ClaimResponse")
+public class ClaimResponseEndpoint {
+
+  @Context
+  private UriInfo uri;
+  
+  @GET
+  public Response searchClaimResponses() {
+    App.DB.setBaseUrl(uri.getBaseUri());
+    Bundle claimResponses = App.DB.search(Database.CLAIM_RESPONSE);
+    String json = App.DB.json(claimResponses);
+    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+  
+  @GET
+  @Path("/{id}")
+  public Response readClaimResponse(@PathParam("id") String id) {
+    String json = null;
+    if (id == null) {
+      // Search
+      Bundle claimResponses = App.DB.search(Database.CLAIM_RESPONSE);
+      json = App.DB.json(claimResponses);
+    } else {
+      // Read
+      ClaimResponse claimResponse = (ClaimResponse) App.DB.read(Database.CLAIM_RESPONSE, id);
+      if (claimResponse == null) {
+        return Response.status(Status.NOT_FOUND).build();
+      }
+      json = App.DB.json(claimResponse);
+    }
+    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/src/main/java/org/hl7/davinci/priorauth/CorsHeaders.java
+++ b/src/main/java/org/hl7/davinci/priorauth/CorsHeaders.java
@@ -1,0 +1,21 @@
+package org.hl7.davinci.priorauth;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@ApplicationScoped
+@Provider
+public class CorsHeaders implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException {
+        response.getHeaders().add("Access-Control-Allow-Origin", "*");
+        response.getHeaders().add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization");
+        response.getHeaders().add("Access-Control-Allow-Credentials", "true");
+        response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+    }
+}

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -1,0 +1,184 @@
+package org.hl7.davinci.priorauth;
+
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Date;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.Resource;
+
+/**
+ * The Database is responsible for storing and retrieving FHIR resources.
+ */
+public class Database {
+  /** Bundle Resource */
+  public static final String BUNDLE = "Bundle";
+  /** Claim Resource */
+  public static final String CLAIM = "Claim";
+  /** ClaimResponse Resource */
+  public static final String CLAIM_RESPONSE = "ClaimResponse";
+
+  // DB_CLOSE_DELAY=-1 maintains the DB in memory after all connections closed
+  // (so that we don't lose everything between a connection closing and the next being opened)
+  private static final String JDBC_STRING = "jdbc:h2:./database;DB_CLOSE_DELAY=-1";
+
+  static {
+    try {
+      Class.forName("org.h2.Driver");
+    } catch (ClassNotFoundException e) {
+      throw new Error(e);
+    }
+  }
+
+  private Connection getConnection() throws SQLException {
+    Connection connection = DriverManager.getConnection(JDBC_STRING);
+    connection.setAutoCommit(true);
+    return connection;
+  }
+
+  /** The base URL of the microservice, for population Bundle.entry.fullUrl. */
+  private String baseUrl;
+
+  public Database() {
+    String[] tables = { BUNDLE, CLAIM, CLAIM_RESPONSE };
+    try (Connection connection = getConnection()) {
+      for (String table : tables) {
+        connection.prepareStatement(
+            "CREATE TABLE IF NOT EXISTS " + table + " (id varchar, resource clob)")
+        .execute();   
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Search the database for the given resourceType.
+   * @param resourceType - the FHIR resourceType to search.
+   * @return Bundle - the search result Bundle.
+   */
+  public Bundle search(String resourceType) {
+    Bundle results = new Bundle();
+    results.setType(BundleType.SEARCHSET);
+    results.setTimestamp(new Date());
+    try (Connection connection = getConnection()) {
+      PreparedStatement stmt = connection.prepareStatement(
+          "SELECT id, resource FROM " + resourceType);
+      ResultSet rs = stmt.executeQuery();
+      int total = 0;
+      while (rs.next()) {
+        String id = rs.getString("id");
+        String json = rs.getString("resource");
+        Resource resource = (Resource) App.FHIR_CTX.newJsonParser().parseResource(json);
+        resource.setId(id);
+        BundleEntryComponent entry = new BundleEntryComponent();
+        entry.setFullUrl(baseUrl + "fhir/" + resourceType + "/" + id);
+        entry.setResource(resource);
+        results.addEntry(entry);
+        total += 1;
+      }
+      results.setTotal(total);
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+    return results;
+  }
+
+  /**
+   * Read a specific resource from the database.
+   * @param resourceType - the FHIR resourceType to read.
+   * @param id - the ID of the resource.
+   * @return IBaseResource - if the resource exists, otherwise null.
+   */
+  public IBaseResource read(String resourceType, String id) {
+    IBaseResource result = null;
+    if (resourceType != null && id != null) {
+      try (Connection connection = getConnection()) {
+        PreparedStatement stmt = connection.prepareStatement(
+            "SELECT id, resource FROM " + resourceType + " WHERE id = ?");
+        stmt.setString(1, id);
+        ResultSet rs = stmt.executeQuery();
+        if (rs.next()) {
+          String json = rs.getString("resource");
+          Resource resource = (Resource) App.FHIR_CTX.newJsonParser().parseResource(json);
+          resource.setId(id);
+          result = resource;
+        }
+      } catch (SQLException e) {
+        e.printStackTrace();
+      }      
+    }
+    return result;
+  }
+
+  /**
+   * Insert a resource into the database.
+   * @param resourceType - the resource type.
+   * @param id - the resource id.
+   * @param resource - the resource itself.
+   * @return boolean - whether or not the resource was written.
+   */
+  public boolean write(String resourceType, String id, IBaseResource resource) {
+    boolean result = false;
+    if (resourceType != null && id != null && resource != null) {
+      try (Connection connection = getConnection()) {
+        PreparedStatement stmt = connection.prepareStatement(
+            "INSERT INTO " + resourceType + " (id, resource) VALUES (?,?);");
+        stmt.setString(1, id);
+        stmt.setString(2, json(resource));
+        result = stmt.execute();
+      } catch (SQLException e) {
+        e.printStackTrace();
+      } 
+    }
+    return result;
+  }
+
+  /**
+   * Delete a particular resource with a given id.
+   * @param resourceType - the resource type to delete.
+   * @param id - the id of the resource to delete.
+   * @return boolean - whether or not the resource was deleted.
+   */
+  public boolean delete(String resourceType, String id) {
+    boolean result = false;
+    if (resourceType != null && id != null) {
+      try (Connection connection = getConnection()) {
+        PreparedStatement stmt = connection.prepareStatement(
+            "DELETE FROM " + resourceType + " WHERE id = ?;");
+        stmt.setString(1, id);
+        result = stmt.execute();
+      } catch (SQLException e) {
+        e.printStackTrace();
+      } 
+    }
+    return result;
+  }
+
+  /**
+   * Set the base URI for the microservice. This is necessary so
+   * Bundle.entry.fullUrl data is accurately populated.
+   * @param base - from @Context UriInfo uri.getBaseUri()
+   */
+  public void setBaseUrl(URI base) {
+    this.baseUrl = base.toString();
+  }
+
+  /**
+   * Convert a FHIR resource into JSON.
+   * @param resource - the resource to convert to JSON.
+   * @return String - the JSON.
+   */
+  public String json(IBaseResource resource) {
+    String json =
+        App.FHIR_CTX.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource);
+    return json;
+  }
+}

--- a/src/main/java/org/hl7/davinci/priorauth/Metadata.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Metadata.java
@@ -77,7 +77,7 @@ public class Metadata {
     claim.setType("Claim");
     // TODO claim.setSupportedProfile(theSupportedProfile);
     claim.addInteraction().setCode(TypeRestfulInteraction.READ);
-    // TODO support claim search
+    claim.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);    
     claim.addOperation()
       .setName("$submit")
       .setDefinition("http://hl7.org/fhir/OperationDefinition/Claim-submit");
@@ -89,9 +89,17 @@ public class Metadata {
     claimResponse.setType("ClaimResponse");
     // TODO claimResponse.setSupportedProfile(theSupportedProfile);
     claimResponse.addInteraction().setCode(TypeRestfulInteraction.READ);
-    // TODO support claimResponse search
+    claimResponse.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);    
     rest.addResource(claimResponse);
-    
+
+    // Bundle Resource
+    CapabilityStatementRestResourceComponent bundle =
+        new CapabilityStatementRestResourceComponent();
+    bundle.setType("Bundle");
+    bundle.addInteraction().setCode(TypeRestfulInteraction.READ);
+    bundle.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);    
+    rest.addResource(bundle);
+  
     metadata.addRest(rest);
 
     String json =

--- a/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
@@ -1,0 +1,117 @@
+package org.hl7.davinci.priorauth;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.junit.MonoMeecrowave;
+import org.apache.meecrowave.testing.ConfigurationInject;
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import ca.uhn.fhir.validation.ValidationResult;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@RunWith(MonoMeecrowave.Runner.class)
+public class BundleEndpointTest {
+
+  @ConfigurationInject
+  private Meecrowave.Builder config;
+  private static OkHttpClient client;
+   
+  @BeforeClass
+  public static void setup() throws FileNotFoundException {
+    client = new OkHttpClient();
+
+    // Create a single test Bundle
+    Path modulesFolder = Paths.get("src/test/resources");
+    Path fixture = modulesFolder.resolve("bundle-minimal.json");
+    FileInputStream inputStream = new FileInputStream(fixture.toString());
+    Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
+    App.DB.write(Database.BUNDLE, "minimal", bundle);
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    App.DB.delete(Database.BUNDLE, "minimal");
+  }
+
+  @Test
+  public void searchBundles() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that we can GET /fhir/Bundle.
+    Request request = new Request.Builder()
+        .url(base + "/Bundle")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(200, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON Bundle
+    String body = response.body().string();
+    Bundle bundle =
+        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Assert.assertNotNull(bundle);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(bundle);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void bundleExists() {
+    Bundle bundle = (Bundle) App.DB.read(Database.BUNDLE, "minimal");
+    Assert.assertNotNull(bundle);
+  }
+
+  @Test
+  public void getBundle() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that non-existent Bundle returns 404.
+    Request request = new Request.Builder()
+        .url(base + "/Bundle/minimal")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(200, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON Bundle
+    String body = response.body().string();
+    Bundle bundle =
+        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Assert.assertNotNull(bundle);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(bundle);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void getBundleThatDoesNotExist() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that non-existent Bundle returns 404.
+    Request request = new Request.Builder()
+        .url(base + "/Bundle/BundlemThatDoesNotExist")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(404, response.code());
+  }
+}

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimEndpointTest.java
@@ -1,0 +1,118 @@
+package org.hl7.davinci.priorauth;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.junit.MonoMeecrowave;
+import org.apache.meecrowave.testing.ConfigurationInject;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Claim;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import ca.uhn.fhir.validation.ValidationResult;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@RunWith(MonoMeecrowave.Runner.class)
+public class ClaimEndpointTest {
+
+  @ConfigurationInject
+  private Meecrowave.Builder config;
+  private static OkHttpClient client;
+   
+  @BeforeClass
+  public static void setup() throws FileNotFoundException {
+    client = new OkHttpClient();
+
+    // Create a single test Claim
+    Path modulesFolder = Paths.get("src/test/resources");
+    Path fixture = modulesFolder.resolve("claim-minimal.json");
+    FileInputStream inputStream = new FileInputStream(fixture.toString());
+    Claim claim = (Claim) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
+    App.DB.write(Database.CLAIM, "minimal", claim);
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    App.DB.delete(Database.CLAIM, "minimal");
+  }
+
+  @Test
+  public void searchClaims() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that we can GET /fhir/Claim.
+    Request request = new Request.Builder()
+        .url(base + "/Claim")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(200, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON Bundle
+    String body = response.body().string();
+    Bundle bundle =
+        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Assert.assertNotNull(bundle);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(bundle);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void claimExists() {
+    Claim claim = (Claim) App.DB.read(Database.CLAIM, "minimal");
+    Assert.assertNotNull(claim);
+  }
+
+  @Test
+  public void getClaim() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that non-existent Claim returns 404.
+    Request request = new Request.Builder()
+        .url(base + "/Claim/minimal")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(200, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON Bundle
+    String body = response.body().string();
+    Claim claim =
+        (Claim) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Assert.assertNotNull(claim);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(claim);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void getClaimThatDoesNotExist() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that non-existent Claim returns 404.
+    Request request = new Request.Builder()
+        .url(base + "/Claim/ClaimThatDoesNotExist")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(404, response.code());
+  }
+}

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
@@ -1,0 +1,118 @@
+package org.hl7.davinci.priorauth;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.junit.MonoMeecrowave;
+import org.apache.meecrowave.testing.ConfigurationInject;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ClaimResponse;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import ca.uhn.fhir.validation.ValidationResult;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@RunWith(MonoMeecrowave.Runner.class)
+public class ClaimResponseEndpointTest {
+
+  @ConfigurationInject
+  private Meecrowave.Builder config;
+  private static OkHttpClient client;
+   
+  @BeforeClass
+  public static void setup() throws FileNotFoundException {
+    client = new OkHttpClient();
+
+    // Create a single test Claim
+    Path modulesFolder = Paths.get("src/test/resources");
+    Path fixture = modulesFolder.resolve("claimresponse-minimal.json");
+    FileInputStream inputStream = new FileInputStream(fixture.toString());
+    ClaimResponse claimResponse = (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
+    App.DB.write(Database.CLAIM_RESPONSE, "minimal", claimResponse);
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    App.DB.delete(Database.CLAIM_RESPONSE, "minimal");
+  }
+
+  @Test
+  public void searchClaimResponses() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that we can GET /fhir/ClaimResponse.
+    Request request = new Request.Builder()
+        .url(base + "/ClaimResponse")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(200, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON Bundle
+    String body = response.body().string();
+    Bundle bundle =
+        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Assert.assertNotNull(bundle);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(bundle);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void claimResponseExists() {
+    ClaimResponse claimResponse = (ClaimResponse) App.DB.read(Database.CLAIM_RESPONSE, "minimal");
+    Assert.assertNotNull(claimResponse);
+  }
+
+  @Test
+  public void getClaimResponse() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that non-existent ClaimResponse returns 404.
+    Request request = new Request.Builder()
+        .url(base + "/ClaimResponse/minimal")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(200, response.code());
+ 
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON Bundle
+    String body = response.body().string();
+    ClaimResponse claimResponse =
+        (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Assert.assertNotNull(claimResponse);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(claimResponse);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void getClaimResponseThatDoesNotExist() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+
+    // Test that non-existent ClaimResponse returns 404.
+    Request request = new Request.Builder()
+        .url(base + "/ClaimResponse/ClaimResponseThatDoesNotExist")
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(404, response.code());
+  }
+}

--- a/src/test/java/org/hl7/davinci/priorauth/DatabaseTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/DatabaseTest.java
@@ -1,0 +1,32 @@
+package org.hl7.davinci.priorauth;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.uhn.fhir.validation.ValidationResult;
+
+public class DatabaseTest {
+
+  @Test
+  public void testSearch() {
+    Bundle results = App.DB.search(Database.BUNDLE);
+    Assert.assertNotNull(results);
+    Assert.assertEquals(BundleType.SEARCHSET, results.getType());
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(results);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void testJson() {
+    Bundle bundle = new Bundle();
+    bundle.setType(BundleType.SEARCHSET);
+    bundle.setTotal(0);
+    
+    String json = App.DB.json(bundle);
+    Assert.assertNotNull(json);
+  }
+}

--- a/src/test/java/org/hl7/davinci/priorauth/ValidationHelper.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ValidationHelper.java
@@ -1,0 +1,40 @@
+package org.hl7.davinci.priorauth;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import ca.uhn.fhir.parser.DataFormatException;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.SingleValidationMessage;
+import ca.uhn.fhir.validation.ValidationResult;
+
+/**
+ * Helper class for validation of FHIR resources.
+ */
+public class ValidationHelper {
+  /**
+   * Validate the FHIR resource and print (STDOUT) error messages.
+   * @param resource - the FHIR resource to validate.
+   * @return ValidationResult - the validation results.
+   */
+  public static ValidationResult validate(IBaseResource resource) {
+    // Test the response is VALID
+    FhirValidator validator = App.FHIR_CTX.newValidator();
+    validator.setValidateAgainstStandardSchema(true);
+    validator.setValidateAgainstStandardSchematron(true);
+    ValidationResult result = validator.validateWithResult(resource);
+
+    // If the validation failed, print out the errors before we fail the test.
+    if (!result.isSuccessful()) {
+      try {
+        String body = App.FHIR_CTX.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource);
+        System.out.println(body);        
+      } catch (DataFormatException e) {
+        System.out.println("ERROR Outputting JSON");
+      }
+      for (SingleValidationMessage message : result.getMessages()) {
+        System.out.println(message.getSeverity() + ": " + message.getMessage());
+      }
+    }
+    return result;
+  }
+}

--- a/src/test/resources/bundle-minimal.json
+++ b/src/test/resources/bundle-minimal.json
@@ -1,0 +1,6 @@
+{
+    "resourceType": "Bundle",
+    "type": "searchset",
+    "timestamp": "2019-04-12T18:42:58.902-04:00",
+    "total": 0
+}

--- a/src/test/resources/claim-minimal.json
+++ b/src/test/resources/claim-minimal.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "Claim",
+  "id": "minimal",
+  "status": "draft",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+        "code": "professional",
+        "display": "Professional"
+      }
+    ]
+  },
+  "use": "preauthorization",
+  "patient": {
+    "reference": "Patient/1"
+  },
+  "created": "2019-04-01",
+  "provider": {
+    "reference": "Organization/1"
+  },
+  "priority": {
+    "coding": [
+      {
+        "code": "normal"
+      }
+    ]
+  },
+  "insurance": [
+    {
+      "sequence": 1,
+      "focal": true,
+      "coverage": {
+        "reference": "Coverage/1"
+      }
+    }
+  ]
+}

--- a/src/test/resources/claimresponse-minimal.json
+++ b/src/test/resources/claimresponse-minimal.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "ClaimResponse",
+  "id": "minimal",
+  "status": "draft",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+        "code": "professional",
+        "display": "Professional"
+      }
+    ]
+  },
+  "use": "preauthorization",
+  "patient": {
+    "reference": "Patient/1"
+  },
+  "created": "2019-04-01",
+  "insurer": {
+    "reference": "Organization/1"
+  },
+  "outcome": "queued"
+}


### PR DESCRIPTION
Adds basic read and search support for Bundle, Claim, and ClaimResponse resources.

- `fhir/Bundle` -- this endpoint provides the Bundles submitted to the `Claim/$submit` operation
- `fhir/Claim` -- this endpoint provides the Claims submitted to the `Claim/$submit` operation
- `fhir/ClaimResponse` -- this endpoint provides the ClaimResponses returned by the `Claim/$submit` operation

The `Claim/$submit` operation will be written in a separate pull request.