### PR TITLE
Initial implementation of $submit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ curl http://localhost:9000/fhir/ClaimResponse
 
 Submit a prior authorization request:
 ```
-curl
+curl -X POST 
+     -H "Content-Type: application/json" 
+     -d @src/test/resources/claim-complete.json 
+     http://localhost:9000/fhir/Claim/\$submit
 ```
 
 ## Questions and Contributions

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -1,17 +1,33 @@
 package org.hl7.davinci.priorauth;
 
+import java.util.Date;
+import java.util.UUID;
+
 import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Claim;
+import org.hl7.fhir.r4.model.ClaimResponse;
+import org.hl7.fhir.r4.model.ClaimResponse.ClaimResponseStatus;
+import org.hl7.fhir.r4.model.ClaimResponse.RemittanceOutcome;
+import org.hl7.fhir.r4.model.ClaimResponse.Use;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 
 /**
  * The Claim endpoint to READ and SEARCH for submitted claims.
@@ -19,6 +35,8 @@ import org.hl7.fhir.r4.model.Claim;
 @RequestScoped
 @Path("Claim")
 public class ClaimEndpoint {
+
+  String REQUIRES_BUNDLE = "Prior Authorization Claim/$submit Operation requires a Bundle with a single Claim and supporting resources.";
 
   @Context
   private UriInfo uri;
@@ -48,5 +66,92 @@ public class ClaimEndpoint {
       json = App.DB.json(claim);
     }
     return Response.ok(json, MediaType.APPLICATION_JSON).build();
+  }
+
+  @POST
+  @Path("/$submit")
+  public Response submitOperation(String body) {
+    String id = null;
+    Status status = Status.OK;
+    String json = null;
+    try {
+      IBaseResource resource = App.FHIR_CTX.newJsonParser().parseResource(body);
+      if (resource instanceof Bundle) {
+        Bundle bundle = (Bundle) resource;
+        if (bundle.hasEntry() && (bundle.getEntry().size() > 1)
+            && bundle.getEntryFirstRep().hasResource()
+            && bundle.getEntryFirstRep().getResource().getResourceType() == ResourceType.Claim) {
+          // Store the submission...
+          // Generate a shared id...
+          id = UUID.randomUUID().toString();
+
+          // Store the bundle...
+          bundle.setId(id);
+          App.DB.write(Database.BUNDLE, id, bundle);
+
+          // Store the claim...
+          Claim claim = (Claim) bundle.getEntryFirstRep().getResource();
+          claim.setId(id);
+          App.DB.write(Database.CLAIM, id, claim);
+
+          // Process the claim...
+          // TODO
+
+          // Generate the claim response...
+          ClaimResponse response = new ClaimResponse();
+          response.setStatus(ClaimResponseStatus.ACTIVE);
+          response.setType(claim.getType());
+          response.setUse(Use.PREAUTHORIZATION);
+          response.setPatient(claim.getPatient());
+          response.setCreated(new Date());
+          if (claim.hasInsurer()) {
+            response.setInsurer(claim.getInsurer());
+          } else {
+            response.setInsurer(new Reference().setDisplay("Unknown"));
+          }
+          response.setRequest(new Reference(uri.getBaseUri() + "Claim/" + id));
+          response.setOutcome(RemittanceOutcome.COMPLETE);
+          response.setDisposition("Granted");
+          response.setPreAuthRef(id);
+          // TODO response.setPreAuthPeriod(period)?
+          // Store the claim response...
+          response.setId(id);
+          App.DB.write(Database.CLAIM_RESPONSE, id, response);
+
+          // Respond...
+          json = App.DB.json(response);
+        } else {
+          // Claim is required...
+          status = Status.BAD_REQUEST;
+          OperationOutcome error = error(IssueSeverity.ERROR, IssueType.INVALID, REQUIRES_BUNDLE);
+          json = App.DB.json(error);
+        }
+      } else {
+        // Bundle is required...
+        status = Status.BAD_REQUEST;
+        OperationOutcome error = error(IssueSeverity.ERROR, IssueType.INVALID, REQUIRES_BUNDLE);
+        json = App.DB.json(error);
+      }
+    } catch (Exception e) {
+      // The submission failed so spectacularly that we need
+      // catch an exception and send back an error message...
+      status = Status.BAD_REQUEST;
+      OperationOutcome error = error(IssueSeverity.FATAL, IssueType.STRUCTURE, e.getMessage());
+      json = App.DB.json(error);
+    }
+    ResponseBuilder builder = Response.status(status).encoding(MediaType.APPLICATION_JSON).entity(json);
+    if (id != null) {
+      builder = builder.header("Location", uri.getBaseUri() + "ClaimResponse/" + id);
+    }
+    return builder.build();
+  }
+
+  private OperationOutcome error(IssueSeverity severity, IssueType type, String message) {
+    OperationOutcome error = new OperationOutcome();
+    OperationOutcomeIssueComponent issue = error.addIssue();
+    issue.setSeverity(severity);
+    issue.setCode(type);
+    issue.setDiagnostics(message);
+    return error;
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -79,7 +79,7 @@ public class Database {
         Resource resource = (Resource) App.FHIR_CTX.newJsonParser().parseResource(json);
         resource.setId(id);
         BundleEntryComponent entry = new BundleEntryComponent();
-        entry.setFullUrl(baseUrl + "fhir/" + resourceType + "/" + id);
+        entry.setFullUrl(baseUrl + resourceType + "/" + id);
         entry.setResource(resource);
         results.addEntry(entry);
         total += 1;

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
@@ -1,0 +1,164 @@
+package org.hl7.davinci.priorauth;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.junit.MonoMeecrowave;
+import org.apache.meecrowave.testing.ConfigurationInject;
+import org.hl7.fhir.r4.model.ClaimResponse;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import ca.uhn.fhir.validation.ValidationResult;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@RunWith(MonoMeecrowave.Runner.class)
+public class ClaimSubmitTest {
+  
+  public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+  @ConfigurationInject
+  private Meecrowave.Builder config;
+  private static OkHttpClient client;
+
+  /** List of resource IDs that will need to be cleaned up after the tests */
+  private static List<String> resourceIds;
+  /** Prior Authorization claim fixture */
+  private static String completeClaim;
+  private static String emptyBundle;
+  private static String claimOnly;
+  private static String bundleWithOnlyClaim;
+   
+  @BeforeClass
+  public static void setup() throws IOException {
+    client = new OkHttpClient();
+    resourceIds = new ArrayList<String>();
+
+    // Read in the test fixtures...
+    Path modulesFolder = Paths.get("src/test/resources");
+    Path fixture = modulesFolder.resolve("claim-complete.json");
+    completeClaim = new String(Files.readAllBytes(fixture));
+
+    fixture = modulesFolder.resolve("bundle-minimal.json");
+    emptyBundle = new String(Files.readAllBytes(fixture));
+
+    fixture = modulesFolder.resolve("claim-minimal.json");
+    claimOnly = new String(Files.readAllBytes(fixture));
+
+    fixture = modulesFolder.resolve("bundle-with-only-claim.json");
+    bundleWithOnlyClaim = new String(Files.readAllBytes(fixture));
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    for (String id : resourceIds) {
+      System.out.println("Deleting Resources with ID = " + id);
+      App.DB.delete(Database.BUNDLE, id);      
+      App.DB.delete(Database.CLAIM, id);      
+      App.DB.delete(Database.CLAIM_RESPONSE, id);      
+    }
+  }
+
+  @Test
+  public void submitCompleteClaim() throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+    
+    // Test that we can POST /fhir/Claim/$submit
+    RequestBody requestBody = RequestBody.create(JSON, completeClaim);
+    Request request = new Request.Builder()
+        .url(base + "/Claim/$submit")
+        .post(requestBody)
+        .build();
+    Response response = client.newCall(request).execute();
+
+    // Check Location header if it exists...
+    String location = response.header("Location");
+    if (location != null) {
+      int index = location.indexOf("fhir/ClaimResponse/");
+      if (index >= 0) {
+        resourceIds.add(location.substring(index + 19));
+      }
+    }
+
+    // Check that the claim succeeded
+    Assert.assertEquals(200, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON ClaimResponse
+    String responseBody = response.body().string();
+    ClaimResponse claimResponse =
+        (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(responseBody);
+    Assert.assertNotNull(claimResponse);
+
+    // Make sure we clean up afterwards...
+    String id = claimResponse.getId().substring(14);
+    resourceIds.add(id);
+
+    // Test that the database contains the proper entries
+    Assert.assertNotNull(App.DB.read(Database.BUNDLE, id));
+    Assert.assertNotNull(App.DB.read(Database.CLAIM, id));
+    Assert.assertNotNull(App.DB.read(Database.CLAIM_RESPONSE, id));
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(claimResponse);
+    Assert.assertTrue(result.isSuccessful());
+  }
+
+  @Test
+  public void submitEmptyBundle() throws IOException {
+    checkErrors(emptyBundle);
+  }
+
+  @Test
+  public void submitClaimOnly() throws IOException {
+    checkErrors(claimOnly);
+  }
+
+  @Test
+  public void submitBundleWithOnlyClaim() throws IOException {
+    checkErrors(bundleWithOnlyClaim);
+  }
+
+  private void checkErrors(String body) throws IOException {
+    String base = "http://localhost:" + config.getHttpPort();
+    
+    // Test that we can POST /fhir/Claim/$submit
+    RequestBody requestBody = RequestBody.create(JSON, body);
+    Request request = new Request.Builder()
+        .url(base + "/Claim/$submit")
+        .post(requestBody)
+        .build();
+    Response response = client.newCall(request).execute();
+    Assert.assertEquals(400, response.code());
+
+    // Test the response has CORS headers
+    String cors = response.header("Access-Control-Allow-Origin");
+    Assert.assertEquals("*", cors);
+
+    // Test the response is a JSON OperationOutcome
+    String responseBody = response.body().string();
+    OperationOutcome error =
+        (OperationOutcome) App.FHIR_CTX.newJsonParser().parseResource(responseBody);
+    Assert.assertNotNull(error);
+
+    // Validate the response.
+    ValidationResult result = ValidationHelper.validate(error);
+    Assert.assertTrue(result.isSuccessful());
+  }
+}

--- a/src/test/resources/bundle-with-only-claim.json
+++ b/src/test/resources/bundle-with-only-claim.json
@@ -1,0 +1,46 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Claim",
+        "id": "minimal",
+        "status": "draft",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "preauthorization",
+        "patient": {
+          "reference": "Patient/1"
+        },
+        "created": "2019-04-01",
+        "provider": {
+          "reference": "Organization/1"
+        },
+        "priority": {
+          "coding": [
+            {
+              "code": "normal"
+            }
+          ]
+        },
+        "insurance": [
+          {
+            "sequence": 1,
+            "focal": true,
+            "coverage": {
+              "reference": "Coverage/1"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/claim-complete.json
+++ b/src/test/resources/claim-complete.json
@@ -1,0 +1,182 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Claim",
+        "id": "minimal",
+        "status": "draft",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "preauthorization",
+        "patient": {
+          "reference": "Patient/f31500e8-15cb-4e8e-8c6e-a001edc6604e"
+        },
+        "created": "2019-04-01",
+        "provider": {
+          "reference": "Practitioner/0fab22ec-49a2-4465-bd62-33b53283de21"
+        },
+        "priority": {
+          "coding": [
+            {
+              "code": "normal"
+            }
+          ]
+        },
+        "insurance": [
+          {
+            "sequence": 1,
+            "focal": true,
+            "coverage": {
+              "reference": "Coverage/0f58e588-eecd-4ab3-9316-f3d02a3ba39d"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "f31500e8-15cb-4e8e-8c6e-a001edc6604e",
+        "gender": "male",
+        "birthDate": "1979-07-04",
+        "address": [
+          {
+            "use": "home",
+            "type": "both",
+            "state": "MA"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "0fab22ec-49a2-4465-bd62-33b53283de21",
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1122334455"
+          }
+        ],
+        "name": [
+          {
+            "family": "Doe",
+            "given": [
+              "Jane"
+            ],
+            "prefix": [
+              "Dr."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "75f39025-65db-43c8-9127-693cdf75e712",
+        "name": "Centers for Medicare and Medicaid Services"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Location",
+        "id": "99595dfb-cdd8-4813-8477-4a9fb40d6c54",
+        "address": {
+          "line": [
+            "100 Good St"
+          ],
+          "city": "Bedford",
+          "state": "MA",
+          "postalCode": "01730"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "f0b0cf14-4066-403f-b217-e92e73c350eb",
+        "practitioner": {
+          "reference": "Practitioner/0fab22ec-49a2-4465-bd62-33b53283de21"
+        },
+        "location": [
+          {
+            "reference": "Location/99595dfb-cdd8-4813-8477-4a9fb40d6c54"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Coverage",
+        "id": "0f58e588-eecd-4ab3-9316-f3d02a3ba39d",
+        "payor": [
+          {
+            "reference": "Organization/75f39025-65db-43c8-9127-693cdf75e712"
+          }
+        ],
+        "grouping": {
+          "plan": "Medicare Part D"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "DeviceRequest",
+        "id": "123",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/davinci-crd/STU3/StructureDefinition/profile-devicerequest-stu3"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://build.fhir.org/ig/HL7/davinci-crd/STU3/ext-insurance.html",
+            "valueReference": {
+              "reference": "Coverage/0f58e588-eecd-4ab3-9316-f3d02a3ba39d"
+            }
+          }
+        ],
+        "status": "draft",
+        "codeCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://bluebutton.cms.gov/resources/codesystem/hcpcs",
+              "code": "E0424",
+              "display": "Stationary Compressed Gaseous Oxygen System, Rental"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f31500e8-15cb-4e8e-8c6e-a001edc6604e"
+        },
+        "performer": {
+          "reference": "PractitionerRole/f0b0cf14-4066-403f-b217-e92e73c350eb"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Device",
+        "type": {
+          "coding": [
+            {
+              "system": "https://bluebutton.cms.gov/resources/codesystem/hcpcs",
+              "code": "E0424",
+              "display": "Stationary Compressed Gaseous Oxygen System, Rental"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the initial skeleton implementation of the `$submit` operation.

It merely validates that the `POST` contained a `Bundle` where the first resource is `Claim` and then responds with a granted `ClaimResponse` with a preauthorization reference ID.

Server-side a `Bundle`, `Claim`, and `ClaimResponse` resource are also created for searching and reading, with the same ID.

Future work includes validation against Implementation Guide profiles (pending) and business logic (e.g. possibly some type of content validation against CQL).