### PR TITLE
Add the ability to delete resources from the demo server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,18 @@ Service | Methods | Description
 `/metadata` | `GET` | The FHIR [capabilities interaction](http://hl7.org/fhir/R4/http.html#capabilities) that returns a FHIR [CapabilityStatement](http://hl7.org/fhir/R4/capabilitystatement.html) resource describing these services.
 `/Bundle` | `GET` | The FHIR [Bundle](http://hl7.org/fhir/R4/bundle.html) endpoint returns all the `Bundle`s that were submitted to the `Claim/$submit` operation.
 `/Bundle/{id}` | `GET` | Gets a single `Bundle` by `id`
+`/Bundle/{id}` | `DELETE` | Deletes a single `Bundle` by `id`
 `/Claim` | `GET` | The FHIR [Claim](http://hl7.org/fhir/R4/claim.html) endpoint returns all the `Claim`s that were submitted to the `Claim/$submit` operation.
 `/Claim/{id}` | `GET` | Gets a single `Claim` by `id`
+`/Claim/{id}` | `DELETE` | Deletes a single `Claim` by `id`
 `/Claim/$submit` | `POST` | Submit a `Bundle` containing a Prior Authorization `Claim` with all the necessary supporting resources. The response to a successful submission is a `ClaimResponse`.
 `/ClaimResponse` | `GET` | The FHIR [ClaimResponse](http://hl7.org/fhir/R4/claimresponse.html) endpoint returns all the `ClaimResponse`s that were generated in response to `Claim/$submit` operations.
 `/ClaimResponse/{id}` | `GET` | Gets a single `ClaimResponse` by `id`
+`/ClaimResponse/{id}` | `DELETE` | Deletes a single `ClaimResponse` by `id`
 
 > *Note About IDs*: The Prior Authorization service generates an `id` when a successful `Claim/$submit` operation is performed. The `Bundle` that was submitted will subsequently be available at `/Bundle/{id}`, and the `Claim` from the submission will be available at `/Claim/{id}`, and the `ClaimResponse` will also be available at `/ClaimResponse/{id}`. _All three resources will share the same `id`._
+
+> *Note About DELETE*: A DELETE by `id` to one resource (i.e. `Bundle`, `Claim`, `ClaimResponse`) is a _Cascading Delete_ and it will delete all associated and related resources.
 
 ## Contents of `/Claim/$submit` Submission
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Prior Authorization Reference Implementation
-The Da Vinci Prior Authorization Reference Implementation (RI) is a software project that conforms to the [Prior Authorization Implementation Guide](http://wiki.hl7.org/index.php?title=Da_Vinci_Prior_Authorization_FHIR_IG_Proposal) developed by the [Da Vinci Project](http://www.hl7.org/about/davinci/index.cfm?ref=common) within the [HL7 Standards Organization](http://www.hl7.org/).
+The Da Vinci Prior Authorization Reference Implementation (RI) is a software project that conforms to the [Prior Authorization Implementation Guide (IG)](https://build.fhir.org/ig/HL7/davinci-pas/index.html) and the [Prior Authorization IG Proposal](http://wiki.hl7.org/index.php?title=Da_Vinci_Prior_Authorization_FHIR_IG_Proposal) developed by the [Da Vinci Project](http://www.hl7.org/about/davinci/index.cfm?ref=common) within the [HL7 Standards Organization](http://www.hl7.org/).
 
 ## Requirements
 - Java JDK 8

--- a/src/main/java/org/hl7/davinci/priorauth/BundleEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/BundleEndpoint.java
@@ -1,6 +1,7 @@
 package org.hl7.davinci.priorauth;
 
 import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -12,13 +13,19 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
 
 /**
- * The Bundle endpoint to READ and SEARCH for submitted Bundles.
+ * The Bundle endpoint to READ, SEARCH for, and DELETE submitted Bundles.
  */
 @RequestScoped
 @Path("Bundle")
 public class BundleEndpoint {
+
+  String REQUIRES_ID = "Instance ID is required: DELETE Bundle/{id}";
+  String DELETED_MSG = "Deleted Bundle and all related and referenced resources.";
 
   @Context
   private UriInfo uri;
@@ -81,5 +88,49 @@ public class BundleEndpoint {
       xml = App.DB.xml(bundle);
     }
     return Response.ok(xml).build();
+  }
+
+  @DELETE
+  @Path("/{id}")
+  @Produces({MediaType.APPLICATION_JSON, "application/fhir+json"})
+  public Response deleteBundle(@PathParam("id") String id) {
+    Status status = Status.OK;
+    OperationOutcome outcome = null;
+    if (id == null) {
+      // Do not delete everything
+      // ID is required...
+      status = Status.BAD_REQUEST;
+      outcome = App.DB.outcome(IssueSeverity.ERROR, IssueType.REQUIRED, REQUIRES_ID);
+    } else {
+      // Cascading delete
+      App.DB.delete(Database.BUNDLE, id);
+      App.DB.delete(Database.CLAIM, id);
+      App.DB.delete(Database.CLAIM_RESPONSE, id);
+      outcome = App.DB.outcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
+    }
+    String json = App.DB.json(outcome);
+    return Response.status(status).entity(json).build();
+  }
+
+  @DELETE
+  @Path("/{id}")
+  @Produces({MediaType.APPLICATION_JSON, "application/fhir+xml"})
+  public Response deleteBundleXml(@PathParam("id") String id) {
+    Status status = Status.OK;
+    OperationOutcome outcome = null;
+    if (id == null) {
+      // Do not delete everything
+      // ID is required...
+      status = Status.BAD_REQUEST;
+      outcome = App.DB.outcome(IssueSeverity.ERROR, IssueType.REQUIRED, REQUIRES_ID);
+    } else {
+      // Cascading delete
+      App.DB.delete(Database.BUNDLE, id);
+      App.DB.delete(Database.CLAIM, id);
+      App.DB.delete(Database.CLAIM_RESPONSE, id);
+      outcome = App.DB.outcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
+    }
+    String xml = App.DB.xml(outcome);
+    return Response.status(status).entity(xml).build();
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimResponseEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimResponseEndpoint.java
@@ -1,6 +1,7 @@
 package org.hl7.davinci.priorauth;
 
 import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -13,13 +14,19 @@ import javax.ws.rs.core.UriInfo;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.ClaimResponse;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
 
 /**
- * The ClaimResponse endpoint to READ and SEARCH for ClaimResponses to submitted claims.
+ * The ClaimResponse endpoint to READ, SEARCH for, and DELETE ClaimResponses to submitted claims.
  */
 @RequestScoped
 @Path("ClaimResponse")
 public class ClaimResponseEndpoint {
+
+  String REQUIRES_ID = "Instance ID is required: DELETE ClaimResponse/{id}";
+  String DELETED_MSG = "Deleted ClaimResponse and all related and referenced resources.";
 
   @Context
   private UriInfo uri;
@@ -83,4 +90,49 @@ public class ClaimResponseEndpoint {
     }
     return Response.ok(xml).build();
   }
+
+  @DELETE
+  @Path("/{id}")
+  @Produces({MediaType.APPLICATION_JSON, "application/fhir+json"})
+  public Response deleteClaimResponse(@PathParam("id") String id) {
+    Status status = Status.OK;
+    OperationOutcome outcome = null;
+    if (id == null) {
+      // Do not delete everything
+      // ID is required...
+      status = Status.BAD_REQUEST;
+      outcome = App.DB.outcome(IssueSeverity.ERROR, IssueType.REQUIRED, REQUIRES_ID);
+    } else {
+      // Cascading delete
+      App.DB.delete(Database.BUNDLE, id);
+      App.DB.delete(Database.CLAIM, id);
+      App.DB.delete(Database.CLAIM_RESPONSE, id);
+      outcome = App.DB.outcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
+    }
+    String json = App.DB.json(outcome);
+    return Response.status(status).entity(json).build();
+  }
+
+  @DELETE
+  @Path("/{id}")
+  @Produces({MediaType.APPLICATION_JSON, "application/fhir+xml"})
+  public Response deleteClaimResponseXml(@PathParam("id") String id) {
+    Status status = Status.OK;
+    OperationOutcome outcome = null;
+    if (id == null) {
+      // Do not delete everything
+      // ID is required...
+      status = Status.BAD_REQUEST;
+      outcome = App.DB.outcome(IssueSeverity.ERROR, IssueType.REQUIRED, REQUIRES_ID);
+    } else {
+      // Cascading delete
+      App.DB.delete(Database.BUNDLE, id);
+      App.DB.delete(Database.CLAIM, id);
+      App.DB.delete(Database.CLAIM_RESPONSE, id);
+      outcome = App.DB.outcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
+    }
+    String xml = App.DB.xml(outcome);
+    return Response.status(status).entity(xml).build();
+  }
+
 }

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -167,6 +167,25 @@ public class Database {
   }
 
   /**
+   * Delete all resources of a particular type.
+   * @param resourceType - the resource type to delete.
+   * @return boolean - whether or not the resources were deleted.
+   */
+  public boolean delete(String resourceType) {
+    boolean result = false;
+    if (resourceType != null) {
+      try (Connection connection = getConnection()) {
+        PreparedStatement stmt = connection.prepareStatement(
+            "DELETE FROM " + resourceType + ";");
+        result = stmt.execute();
+      } catch (SQLException e) {
+        e.printStackTrace();
+      }
+    }
+    return result;
+  }
+
+  /**
    * Set the base URI for the microservice. This is necessary so
    * Bundle.entry.fullUrl data is accurately populated.
    * @param base - from @Context UriInfo uri.getBaseUri()

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -10,8 +10,12 @@ import java.util.Date;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
@@ -191,5 +195,21 @@ public class Database {
     String xml =
         App.FHIR_CTX.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
     return xml;
+  }
+
+  /**
+   * Create a FHIR OperationOutcome.
+   * @param severity The severity of the result.
+   * @param type The issue type.
+   * @param message The message to return.
+   * @return OperationOutcome - the FHIR resource.
+   */
+  public OperationOutcome outcome(IssueSeverity severity, IssueType type, String message) {
+    OperationOutcome error = new OperationOutcome();
+    OperationOutcomeIssueComponent issue = error.addIssue();
+    issue.setSeverity(severity);
+    issue.setCode(type);
+    issue.setDiagnostics(message);
+    return error;
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
@@ -1,0 +1,35 @@
+package org.hl7.davinci.priorauth;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@RequestScoped
+@Path("$expunge")
+public class ExpungeOperation {
+
+  @GET
+  public Response getExpunge() {
+    return expungeDatabase();
+  }
+
+  @POST
+  public Response postExpunge() {
+    return expungeDatabase();
+  }
+
+  /**
+   * Delete all the data in the database. Useful if the
+   * demonstration database becomes too large and unwieldy.
+   * @return - HTTP 200
+   */
+  private Response expungeDatabase() {
+    // Cascading delete of everything...
+    App.DB.delete(Database.BUNDLE);
+    App.DB.delete(Database.CLAIM);
+    App.DB.delete(Database.CLAIM_RESPONSE);
+    return Response.ok().build();
+  }
+}

--- a/src/main/java/org/hl7/davinci/priorauth/Metadata.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Metadata.java
@@ -129,7 +129,12 @@ public class Metadata {
     bundle.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);
     bundle.addInteraction().setCode(TypeRestfulInteraction.DELETE);
     rest.addResource(bundle);
-  
+
+    rest.addOperation()
+      .setName("$expunge")
+      .setDefinition("https://smilecdr.com/docs/current/fhir_repository/deleting_data.html#drop-all-data")
+      .setDocumentation("For Demonstration Purposes Only. Deletes all data from the demonstration database. Not part of the Implementation Guide.");
+
     metadata.addRest(rest);
 
     return metadata;

--- a/src/main/java/org/hl7/davinci/priorauth/Metadata.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Metadata.java
@@ -6,8 +6,10 @@ import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementImplementationComponent;
@@ -28,14 +30,20 @@ import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 @Path("metadata")
 public class Metadata {
 
+  @Context
+  private UriInfo uri;
+
   /**
    * Cached CapabilityStatement.
    */
-  private static final CapabilityStatement capabilityStatement = buildCapabilityStatement();
+  private CapabilityStatement capabilityStatement = null;
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, "application/fhir+json"})
   public Response getMetadata() {
+    if (capabilityStatement == null) {
+      capabilityStatement = buildCapabilityStatement();
+    }
     String json = App.DB.json(capabilityStatement);
     return Response.ok(json).build();
   }
@@ -43,6 +51,9 @@ public class Metadata {
   @GET
   @Produces({MediaType.APPLICATION_XML, "application/fhir+xml"})
   public Response getMetadataXml() {
+    if (capabilityStatement == null) {
+      capabilityStatement = buildCapabilityStatement();
+    }
     String xml = App.DB.xml(capabilityStatement);
     return Response.ok(xml).build();
   }
@@ -52,13 +63,13 @@ public class Metadata {
    * Reference Implementation.
    * @return CapabilityStatement - the CapabilityStatement.
    */
-  private static CapabilityStatement buildCapabilityStatement() {
+  private CapabilityStatement buildCapabilityStatement() {
     CapabilityStatement metadata = new CapabilityStatement();
     metadata.setTitle("Da Vinci Prior Authorization Reference Implementation");
     metadata.setStatus(PublicationStatus.DRAFT);
     metadata.setExperimental(true);
     Calendar calendar = Calendar.getInstance();
-    calendar.set(2019, 3, 1, 0, 0, 0);
+    calendar.set(2019, 4, 28, 0, 0, 0);
     metadata.setDate(calendar.getTime());
     metadata.setPublisher("Da Vinci");
     metadata.setKind(CapabilityStatementKind.INSTANCE);
@@ -69,10 +80,13 @@ public class Metadata {
     CapabilityStatementImplementationComponent implementation = 
         new CapabilityStatementImplementationComponent();
     implementation.setDescription(metadata.getTitle());
-    implementation.setUrl("http://wiki.hl7.org/index.php?title=Da_Vinci_Prior_Authorization_FHIR_IG_Proposal");
+    implementation.setUrl(uri.getBaseUri() + "metadata");
     metadata.setImplementation(implementation);
     metadata.setFhirVersion(FHIRVersion._4_0_0);
     metadata.addFormat("json");
+    metadata.addFormat("xml");
+    metadata.addImplementationGuide("https://build.fhir.org/ig/HL7/davinci-pas/index.html");
+    metadata.addImplementationGuide("http://wiki.hl7.org/index.php?title=Da_Vinci_Prior_Authorization_FHIR_IG_Proposal");
     CapabilityStatementRestComponent rest =
         new CapabilityStatementRestComponent();
     rest.setMode(RestfulCapabilityMode.SERVER);
@@ -87,10 +101,14 @@ public class Metadata {
     claim.setType("Claim");
     // TODO claim.setSupportedProfile(theSupportedProfile);
     claim.addInteraction().setCode(TypeRestfulInteraction.READ);
-    claim.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);    
+    claim.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);
+    claim.addInteraction().setCode(TypeRestfulInteraction.DELETE);
     claim.addOperation()
       .setName("$submit")
       .setDefinition("http://hl7.org/fhir/OperationDefinition/Claim-submit");
+    claim.addOperation()
+      .setName("$submit")
+      .setDefinition("https://build.fhir.org/ig/HL7/davinci-pas/Claim-submit.html");
     rest.addResource(claim);
 
     // ClaimResponse Resource
@@ -99,7 +117,8 @@ public class Metadata {
     claimResponse.setType("ClaimResponse");
     // TODO claimResponse.setSupportedProfile(theSupportedProfile);
     claimResponse.addInteraction().setCode(TypeRestfulInteraction.READ);
-    claimResponse.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);    
+    claimResponse.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);
+    claimResponse.addInteraction().setCode(TypeRestfulInteraction.DELETE);
     rest.addResource(claimResponse);
 
     // Bundle Resource
@@ -107,7 +126,8 @@ public class Metadata {
         new CapabilityStatementRestResourceComponent();
     bundle.setType("Bundle");
     bundle.addInteraction().setCode(TypeRestfulInteraction.READ);
-    bundle.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);    
+    bundle.addInteraction().setCode(TypeRestfulInteraction.SEARCHTYPE);
+    bundle.addInteraction().setCode(TypeRestfulInteraction.DELETE);
     rest.addResource(bundle);
   
     metadata.addRest(rest);


### PR DESCRIPTION
In case the prior authorization demo server fills up with unwieldy amounts of data, this pull request adds the ability to `DELETE` resources, or `$expunge` the entire database.

This feature is not part of the Implementation Guide, and is included for demonstration purposes only. It should be used with caution.