### PR TITLE
PRIORAUTH 8: Support Claim Cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The body of the `/Claim/$submit` operation are as follows:
 
 The first `entry` of the submitted `Bundle` should contain a `Claim`, followed by a `QuestionnaireResponse` which includes answers in response to questions presented by Da Vinci [Documentation Templates and Rules](https://github.com/HL7-DaVinci/dtr) (DTR), then the `DeviceRequest` (or other resource type) that actually requires the prior authorization, followed by all supporting FHIR resources including the `Patient`, `Practitioner`, `Coverage`, and relevant `Condition` and `Observation` resources used in DTR calculations or otherwise used as supporting information.
 
+To cancel the Claim submit a `Claim` resource with the `id` of the Claim to cancel and set the `status` to `cancelled`. If the Claim exists and is not already cancelled the database will be update to reflect the cancellation.
+
 ## Response of the `/Claim/$submit` Operation
 
 Assuming the structure and contents of the submitted `Bundle` are adequate, the service will responsed with a `ClaimResponse` as detailed below. Otherwise, the service will respond with an `OperationalOutcome` containing an error message.

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -182,6 +182,7 @@ public class ClaimEndpoint {
     }
 
     String claimId = id;
+    String responseDisposition = "Unknown";
     ClaimResponseStatus responseStatus = ClaimResponseStatus.ACTIVE;
     ClaimStatus status = claim.getStatus();
     if (status == Claim.ClaimStatus.CANCELLED) {
@@ -192,6 +193,7 @@ public class ClaimEndpoint {
         if (initialClaim.getStatus() != Claim.ClaimStatus.CANCELLED) {
           App.DB.update(Database.CLAIM, claimId, "status", status.getDisplay().toLowerCase());
           responseStatus = ClaimResponseStatus.CANCELLED;
+          responseDisposition = "Cancelled";
         } else {
           logger.info("Claim " + claimId + " is already cancelled");
           return null;
@@ -211,6 +213,8 @@ public class ClaimEndpoint {
       String[] claimValues = { id, patient, Database.getStatusFromResource(claim) };
       App.DB.write(Database.CLAIM, Database.CLAIM_KEYS, claimValues, claim);
 
+      // Make up a disposition
+      responseDisposition = "Granted";
     }
     // Process the claim...
     // TODO
@@ -229,7 +233,7 @@ public class ClaimEndpoint {
     }
     response.setRequest(new Reference(uri.getBaseUri() + "Claim/" + id));
     response.setOutcome(RemittanceOutcome.COMPLETE);
-    response.setDisposition("Granted");
+    response.setDisposition(responseDisposition);
     response.setPreAuthRef(id);
     // TODO response.setPreAuthPeriod(period)?
     // Store the claim response...

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -1,6 +1,8 @@
 package org.hl7.davinci.priorauth;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.enterprise.context.RequestScoped;
@@ -205,13 +207,21 @@ public class ClaimEndpoint {
     } else {
       // Store the bundle...
       bundle.setId(id);
-      String[] bundleValues = { id, patient, Database.getStatusFromResource(bundle) };
-      App.DB.write(Database.BUNDLE, Database.BUNDLE_KEYS, bundleValues, bundle);
+      Map<String, Object> bundleMap = new HashMap<String, Object>();
+      bundleMap.put("id", id);
+      bundleMap.put("patient", patient);
+      bundleMap.put("status", Database.getStatusFromResource(bundle));
+      bundleMap.put("resource", bundle);
+      App.DB.write(Database.BUNDLE, bundleMap);
 
       // Store the claim...
       claim.setId(id);
-      String[] claimValues = { id, patient, Database.getStatusFromResource(claim) };
-      App.DB.write(Database.CLAIM, Database.CLAIM_KEYS, claimValues, claim);
+      Map<String, Object> claimMap = new HashMap<String, Object>();
+      claimMap.put("id", id);
+      claimMap.put("patient", patient);
+      claimMap.put("status", Database.getStatusFromResource(claim));
+      claimMap.put("resource", claim);
+      App.DB.write(Database.CLAIM, claimMap);
 
       // Make up a disposition
       responseDisposition = "Granted";
@@ -236,10 +246,16 @@ public class ClaimEndpoint {
     response.setDisposition(responseDisposition);
     response.setPreAuthRef(id);
     // TODO response.setPreAuthPeriod(period)?
-    // Store the claim response...
     response.setId(id);
-    String[] responseValues = { id, claimId, patient, Database.getStatusFromResource(response) };
-    App.DB.write(Database.CLAIM_RESPONSE, Database.CLAIM_RESPONSE_KEYS, responseValues, response);
+
+    // Store the claim respnose...
+    Map<String, Object> responseMap = new HashMap<String, Object>();
+    responseMap.put("id", id);
+    responseMap.put("claimId", claimId);
+    responseMap.put("patient", patient);
+    responseMap.put("status", Database.getStatusFromResource(response));
+    responseMap.put("resource", response);
+    App.DB.write(Database.CLAIM_RESPONSE, responseMap);
 
     // Respond...
     return response;

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -284,7 +284,7 @@ public class Database {
   }
 
   /**
-   * Internal function to get the correct status from a resource depebdibg on the
+   * Internal function to get the correct status from a resource depending on the
    * type
    * 
    * @param resource - the resource.

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -1,5 +1,7 @@
 package org.hl7.davinci.priorauth;
 
+import java.util.*;
+
 import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -35,6 +37,12 @@ public class Database {
   public static final String CLAIM = "Claim";
   /** ClaimResponse Resource */
   public static final String CLAIM_RESPONSE = "ClaimResponse";
+  /** Bundle Table Keys */
+  public static final String[] BUNDLE_KEYS = { "id", "patient", "status", "resource" };
+  /** Claim Table Keys */
+  public static final String[] CLAIM_KEYS = { "id", "patient", "status", "resource" };
+  /** ClaimResponse Table Keys */
+  public static final String[] CLAIM_RESPONSE_KEYS = { "id", "claimId", "patient", "status", "resource" };
 
   // DB_CLOSE_DELAY=-1 maintains the DB in memory after all connections closed
   // (so that we don't lose everything between a connection closing and the next
@@ -59,14 +67,18 @@ public class Database {
   private String baseUrl;
 
   public Database() {
-    String[] tables = { BUNDLE, CLAIM, CLAIM_RESPONSE };
     try (Connection connection = getConnection()) {
-      for (String table : tables) {
-        connection
-            .prepareStatement(
-                "CREATE TABLE IF NOT EXISTS " + table + " (id varchar, patient varchar, status varchar, resource clob)")
-            .execute();
-      }
+      // TODO: make these use the {RESOURCE}_KEYS array
+      String bundleTableStmt = "CREATE TABLE IF NOT EXISTS " + BUNDLE
+          + "(id varchar, patient varchar, status varchar, resource clob);";
+      String claimTableStmt = "CREATE TABLE IF NOT EXISTS " + CLAIM
+          + "(id varchar, patient varchar, status varchar, resource clob);";
+      String claimResponseTableStmt = "CREATE TABLE IF NOT EXISTS " + CLAIM_RESPONSE
+          + "(id varchar, claimId varchar, patient varchar, status varchar, resource clob);";
+
+      connection.prepareStatement(bundleTableStmt).execute();
+      connection.prepareStatement(claimTableStmt).execute();
+      connection.prepareStatement(claimResponseTableStmt).execute();
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -173,39 +185,55 @@ public class Database {
   }
 
   /**
-   * Insert a resource into the database.
+   * Insert a resource into database.
    * 
-   * @param resourceType - the resource type.
-   * @param id           - the resource id.
+   * @param resourceType - the tpye of the resource.
+   * @param keys         - string array of key (table column) names.
+   * @param values       - string array of values to add into the columns.
    * @param resource     - the resource itself.
    * @return boolean - whether or not the resource was written.
    */
-  public boolean write(String resourceType, String id, String patient, IBaseResource resource) {
+  public boolean write(String resourceType, String[] keys, String[] values, IBaseResource resource) {
+    final String commaSeperator = ", ";
+    final String quoteSeperator = "', '";
+    logger.info("Database::write(" + resourceType + ", (" + reduceArray(keys, commaSeperator) + "), ("
+        + reduceArray(values, commaSeperator) + "))");
     boolean result = false;
-    if (resourceType != null && id != null && resource != null) {
+    if (keys != null && values != null && resource != null && keys.length == (values.length + 1)) {
+      try (Connection connection = getConnection()) {
+        String sql = "INSERT INTO " + resourceType + " (" + reduceArray(keys, commaSeperator) + ") VALUES ('"
+            + reduceArray(values, quoteSeperator) + "',?);";
+        PreparedStatement stmt = connection.prepareStatement(sql);
+        stmt.setString(1, json(resource));
+        result = stmt.execute();
+        logger.info(sql);
+      } catch (SQLException e) {
+        e.printStackTrace();
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Update a single column in a row to a new value
+   * 
+   * @param resourceType - the resource type.
+   * @param id           - the resource id.
+   * @param column       - the name of the column to update.
+   * @param value        - the new value.
+   * @return boolean - whether or not the update was successful
+   */
+  public boolean update(String resourceType, String id, String column, String value) {
+    logger.info("Database::update(" + resourceType + ", " + id + ", " + column + ", " + value + ")");
+    boolean result = false;
+    if (resourceType != null && id != null && column != null) {
       try (Connection connection = getConnection()) {
         PreparedStatement stmt = connection
-            .prepareStatement("INSERT INTO " + resourceType + " (id, patient, status, resource) VALUES (?,?,?,?);");
-        String queryStmt = stmt.toString();
-        String status;
-        if (resource instanceof Claim) {
-          Claim claim = (Claim) resource;
-          status = claim.getStatus().getDisplay();
-        } else if (resource instanceof ClaimResponse) {
-          ClaimResponse claimResponse = (ClaimResponse) resource;
-          status = claimResponse.getStatus().getDisplay();
-        } else if (resource instanceof Bundle) {
-          status = "valid";
-        } else {
-          status = "unkown";
-        }
-        status = status.toLowerCase();
-        stmt.setString(1, id);
-        stmt.setString(2, patient);
-        stmt.setString(3, status);
-        stmt.setString(4, json(resource));
+            .prepareStatement("UPDATE " + resourceType + " SET " + column + " = ? WHERE id = ?;");
+        stmt.setString(1, value);
+        stmt.setString(2, id);
+        logger.info(stmt.toString());
         result = stmt.execute();
-        logger.info("write: " + queryStmt + "{1: " + id + ", 2: " + patient + ", 3: " + status + ", 4: Resource}");
       } catch (SQLException e) {
         e.printStackTrace();
       }
@@ -256,6 +284,30 @@ public class Database {
   }
 
   /**
+   * Internal function to get the correct status from a resource depebdibg on the
+   * type
+   * 
+   * @param resource - the resource.
+   * @return - the status of the resource.
+   */
+  public static String getStatusFromResource(IBaseResource resource) {
+    String status;
+    if (resource instanceof Claim) {
+      Claim claim = (Claim) resource;
+      status = claim.getStatus().getDisplay();
+    } else if (resource instanceof ClaimResponse) {
+      ClaimResponse claimResponse = (ClaimResponse) resource;
+      status = claimResponse.getStatus().getDisplay();
+    } else if (resource instanceof Bundle) {
+      status = "valid";
+    } else {
+      status = "unkown";
+    }
+    status = status.toLowerCase();
+    return status;
+  }
+
+  /**
    * Set the base URI for the microservice. This is necessary so
    * Bundle.entry.fullUrl data is accurately populated.
    * 
@@ -302,5 +354,17 @@ public class Database {
     issue.setCode(type);
     issue.setDiagnostics(message);
     return error;
+  }
+
+  /**
+   * Internal method for reducing an array into a string
+   * 
+   * @param arr       - the string array to reduce.
+   * @param separator - the string to connect elements together.
+   * @return a single string representation of the array
+   */
+  private String reduceArray(String[] arr, String separator) {
+    Optional<String> reducedArr = Arrays.stream(arr).reduce((str1, str2) -> str1 + separator + str2);
+    return reducedArr.get();
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
@@ -21,9 +21,9 @@ public class Endpoint {
     static final Boolean requestXml = false;
     static final Boolean requestJson = true;
 
-    static String REQUIRES_ID = "Instance ID is required: DELETE ClaimResponse?identifier=";
-    static String REQUIRES_PATIENT = "Patient Identifier is required: DELETE ClaimResponse?patient.identifier=";
-    static String DELETED_MSG = "Deleted ClaimResponse and all related and referenced resources.";
+    static String REQUIRES_ID = "Instance ID is required: DELETE {resourceType}?identifier=";
+    static String REQUIRES_PATIENT = "Patient Identifier is required: DELETE {resourceType}?patient.identifier=";
+    static String DELETED_MSG = "Deleted resource and all related and referenced resources.";
 
     /**
      * Read a resource from an endpoint in either JSON or XML

--- a/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
@@ -27,7 +27,7 @@ public class BundleEndpointTest {
   @ConfigurationInject
   private Meecrowave.Builder config;
   private static OkHttpClient client;
-   
+
   @BeforeClass
   public static void setup() throws FileNotFoundException {
     client = new OkHttpClient();
@@ -37,7 +37,8 @@ public class BundleEndpointTest {
     Path fixture = modulesFolder.resolve("bundle-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    App.DB.write(Database.BUNDLE, "minimal", "1", bundle);
+    String[] bundleValues = { "minimal", "1", Database.getStatusFromResource(bundle) };
+    App.DB.write(Database.BUNDLE, Database.BUNDLE_KEYS, bundleValues, bundle);
   }
 
   @AfterClass
@@ -50,10 +51,8 @@ public class BundleEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/Bundle.
-    Request request = new Request.Builder()
-        .url(base + "/Bundle?patient.identifier=1")
-        .header("Accept", "application/fhir+json")
-        .build();
+    Request request = new Request.Builder().url(base + "/Bundle?patient.identifier=1")
+        .header("Accept", "application/fhir+json").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -63,8 +62,7 @@ public class BundleEndpointTest {
 
     // Test the response is a JSON Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -77,10 +75,8 @@ public class BundleEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/Bundle.
-    Request request = new Request.Builder()
-        .url(base + "/Bundle?patient.identifier=1")
-        .header("Accept", "application/fhir+xml")
-        .build();
+    Request request = new Request.Builder().url(base + "/Bundle?patient.identifier=1")
+        .header("Accept", "application/fhir+xml").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -90,8 +86,7 @@ public class BundleEndpointTest {
 
     // Test the response is an XML Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -110,10 +105,8 @@ public class BundleEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can get fhir/Bundle/minimal
-    Request request = new Request.Builder()
-        .url(base + "/Bundle?identifier=minimal&patient.identifier=1")
-        .header("Accept", "application/fhir+json")
-        .build();
+    Request request = new Request.Builder().url(base + "/Bundle?identifier=minimal&patient.identifier=1")
+        .header("Accept", "application/fhir+json").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -123,8 +116,7 @@ public class BundleEndpointTest {
 
     // Test the response is a JSON Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -137,10 +129,8 @@ public class BundleEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can get fhir/Bundle/minimal
-    Request request = new Request.Builder()
-        .url(base + "/Bundle?identifier=minimal&patient.identifier=1")
-        .header("Accept", "application/fhir+xml")
-        .build();
+    Request request = new Request.Builder().url(base + "/Bundle?identifier=minimal&patient.identifier=1")
+        .header("Accept", "application/fhir+xml").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -150,8 +140,7 @@ public class BundleEndpointTest {
 
     // Test the response is an XML Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -165,8 +154,7 @@ public class BundleEndpointTest {
 
     // Test that non-existent Bundle returns 404.
     Request request = new Request.Builder()
-        .url(base + "/Bundle?identifier=BundleThatDoesNotExist&patient.identifier=45")
-        .build();
+        .url(base + "/Bundle?identifier=BundleThatDoesNotExist&patient.identifier=45").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(404, response.code());
   }

--- a/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
@@ -5,6 +5,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.meecrowave.Meecrowave;
 import org.apache.meecrowave.junit.MonoMeecrowave;
@@ -37,8 +39,12 @@ public class BundleEndpointTest {
     Path fixture = modulesFolder.resolve("bundle-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    String[] bundleValues = { "minimal", "1", Database.getStatusFromResource(bundle) };
-    App.DB.write(Database.BUNDLE, Database.BUNDLE_KEYS, bundleValues, bundle);
+    Map<String, Object> bundleMap = new HashMap<String, Object>();
+    bundleMap.put("id", "minimal");
+    bundleMap.put("patient", "1");
+    bundleMap.put("status", Database.getStatusFromResource(bundle));
+    bundleMap.put("resource", bundle);
+    App.DB.write(Database.BUNDLE, bundleMap);
   }
 
   @AfterClass

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimEndpointTest.java
@@ -28,7 +28,7 @@ public class ClaimEndpointTest {
   @ConfigurationInject
   private Meecrowave.Builder config;
   private static OkHttpClient client;
-   
+
   @BeforeClass
   public static void setup() throws FileNotFoundException {
     client = new OkHttpClient();
@@ -38,7 +38,8 @@ public class ClaimEndpointTest {
     Path fixture = modulesFolder.resolve("claim-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     Claim claim = (Claim) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    App.DB.write(Database.CLAIM, "minimal", "1", claim);
+    String[] claimValues = { "minimal", "1", Database.getStatusFromResource(claim) };
+    App.DB.write(Database.CLAIM, Database.CLAIM_KEYS, claimValues, claim);
   }
 
   @AfterClass
@@ -51,10 +52,8 @@ public class ClaimEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/Claim.
-    Request request = new Request.Builder()
-        .url(base + "/Claim?patient.identifier=1")
-        .header("Accept", "application/fhir+json")
-        .build();
+    Request request = new Request.Builder().url(base + "/Claim?patient.identifier=1")
+        .header("Accept", "application/fhir+json").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -64,8 +63,7 @@ public class ClaimEndpointTest {
 
     // Test the response is a JSON Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -78,10 +76,8 @@ public class ClaimEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/Claim.
-    Request request = new Request.Builder()
-        .url(base + "/Claim?patient.identifier=1")
-        .header("Accept", "application/fhir+xml")
-        .build();
+    Request request = new Request.Builder().url(base + "/Claim?patient.identifier=1")
+        .header("Accept", "application/fhir+xml").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -91,8 +87,7 @@ public class ClaimEndpointTest {
 
     // Test the response is an XML Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -111,10 +106,8 @@ public class ClaimEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/Claim/minimal.
-    Request request = new Request.Builder()
-        .url(base + "/Claim?identifier=minimal&patient.identifier=1")
-        .header("Accept", "application/fhir+json")
-        .build();
+    Request request = new Request.Builder().url(base + "/Claim?identifier=minimal&patient.identifier=1")
+        .header("Accept", "application/fhir+json").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -124,8 +117,7 @@ public class ClaimEndpointTest {
 
     // Test the response is a JSON Bundle
     String body = response.body().string();
-    Claim claim =
-        (Claim) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Claim claim = (Claim) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(claim);
 
     // Validate the response.
@@ -138,10 +130,8 @@ public class ClaimEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/Claim/minimal.
-    Request request = new Request.Builder()
-        .url(base + "/Claim?identifier=minimal&patient.identifier=1")
-        .header("Accept", "application/fhir+xml")
-        .build();
+    Request request = new Request.Builder().url(base + "/Claim?identifier=minimal&patient.identifier=1")
+        .header("Accept", "application/fhir+xml").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -151,8 +141,7 @@ public class ClaimEndpointTest {
 
     // Test the response is an XML Bundle
     String body = response.body().string();
-    Claim claim =
-        (Claim) App.FHIR_CTX.newXmlParser().parseResource(body);
+    Claim claim = (Claim) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(claim);
 
     // Validate the response.
@@ -165,8 +154,7 @@ public class ClaimEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that non-existent Claim returns 404.
-    Request request = new Request.Builder()
-        .url(base + "/Claim?identifier=ClaimThatDoesNotExist&patient.identifier=45")
+    Request request = new Request.Builder().url(base + "/Claim?identifier=ClaimThatDoesNotExist&patient.identifier=45")
         .build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(404, response.code());

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimEndpointTest.java
@@ -5,6 +5,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.meecrowave.Meecrowave;
 import org.apache.meecrowave.junit.MonoMeecrowave;
@@ -38,8 +40,12 @@ public class ClaimEndpointTest {
     Path fixture = modulesFolder.resolve("claim-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     Claim claim = (Claim) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    String[] claimValues = { "minimal", "1", Database.getStatusFromResource(claim) };
-    App.DB.write(Database.CLAIM, Database.CLAIM_KEYS, claimValues, claim);
+    Map<String, Object> claimMap = new HashMap<String, Object>();
+    claimMap.put("id", "minimal");
+    claimMap.put("patient", "1");
+    claimMap.put("status", Database.getStatusFromResource(claim));
+    claimMap.put("resource", claim);
+    App.DB.write(Database.CLAIM, claimMap);
   }
 
   @AfterClass

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
@@ -5,6 +5,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.meecrowave.Meecrowave;
 import org.apache.meecrowave.junit.MonoMeecrowave;
@@ -38,8 +40,13 @@ public class ClaimResponseEndpointTest {
     Path fixture = modulesFolder.resolve("claimresponse-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     ClaimResponse claimResponse = (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    String[] claimResponseValues = { "minimal", "minimal", "1", Database.getStatusFromResource(claimResponse) };
-    App.DB.write(Database.CLAIM_RESPONSE, Database.CLAIM_RESPONSE_KEYS, claimResponseValues, claimResponse);
+    Map<String, Object> claimResponseMap = new HashMap<String, Object>();
+    claimResponseMap.put("id", "minimal");
+    claimResponseMap.put("claimId", "minimal");
+    claimResponseMap.put("patient", "1");
+    claimResponseMap.put("status", Database.getStatusFromResource(claimResponse));
+    claimResponseMap.put("resource", claimResponse);
+    App.DB.write(Database.CLAIM_RESPONSE, claimResponseMap);
   }
 
   @AfterClass

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
@@ -28,7 +28,7 @@ public class ClaimResponseEndpointTest {
   @ConfigurationInject
   private Meecrowave.Builder config;
   private static OkHttpClient client;
-   
+
   @BeforeClass
   public static void setup() throws FileNotFoundException {
     client = new OkHttpClient();
@@ -38,7 +38,8 @@ public class ClaimResponseEndpointTest {
     Path fixture = modulesFolder.resolve("claimresponse-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     ClaimResponse claimResponse = (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    App.DB.write(Database.CLAIM_RESPONSE, "minimal", "1", claimResponse);
+    String[] claimResponseValues = { "minimal", "1", Database.getStatusFromResource(claimResponse) };
+    App.DB.write(Database.CLAIM_RESPONSE, Database.CLAIM_RESPONSE_KEYS, claimResponseValues, claimResponse);
   }
 
   @AfterClass
@@ -51,10 +52,8 @@ public class ClaimResponseEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/ClaimResponse.
-    Request request = new Request.Builder()
-        .url(base + "/ClaimResponse?patient.identifier=1")
-        .header("Accept", "application/fhir+json")
-        .build();
+    Request request = new Request.Builder().url(base + "/ClaimResponse?patient.identifier=1")
+        .header("Accept", "application/fhir+json").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -64,8 +63,7 @@ public class ClaimResponseEndpointTest {
 
     // Test the response is a JSON Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -78,10 +76,8 @@ public class ClaimResponseEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/ClaimResponse.
-    Request request = new Request.Builder()
-        .url(base + "/ClaimResponse?patient.identifier=1")
-        .header("Accept", "application/fhir+xml")
-        .build();
+    Request request = new Request.Builder().url(base + "/ClaimResponse?patient.identifier=1")
+        .header("Accept", "application/fhir+xml").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -91,8 +87,7 @@ public class ClaimResponseEndpointTest {
 
     // Test the response is an XML Bundle
     String body = response.body().string();
-    Bundle bundle =
-        (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
+    Bundle bundle = (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(bundle);
 
     // Validate the response.
@@ -111,21 +106,18 @@ public class ClaimResponseEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/ClaimResponse/minimal
-    Request request = new Request.Builder()
-        .url(base + "/ClaimResponse?identifier=minimal&patient.identifier=1")
-       .header("Accept", "application/fhir+json")
-       .build();
+    Request request = new Request.Builder().url(base + "/ClaimResponse?identifier=minimal&patient.identifier=1")
+        .header("Accept", "application/fhir+json").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
- 
+
     // Test the response has CORS headers
     String cors = response.header("Access-Control-Allow-Origin");
     Assert.assertEquals("*", cors);
 
     // Test the response is a JSON Bundle
     String body = response.body().string();
-    ClaimResponse claimResponse =
-        (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(body);
+    ClaimResponse claimResponse = (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(claimResponse);
 
     // Validate the response.
@@ -138,10 +130,8 @@ public class ClaimResponseEndpointTest {
     String base = "http://localhost:" + config.getHttpPort();
 
     // Test that we can GET /fhir/ClaimResponse/minimal
-    Request request = new Request.Builder()
-        .url(base + "/ClaimResponse?identifier=minimal&patient.identifier=1")
-       .header("Accept", "application/fhir+xml")
-       .build();
+    Request request = new Request.Builder().url(base + "/ClaimResponse?identifier=minimal&patient.identifier=1")
+        .header("Accept", "application/fhir+xml").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(200, response.code());
 
@@ -151,8 +141,7 @@ public class ClaimResponseEndpointTest {
 
     // Test the response is an XML Bundle
     String body = response.body().string();
-    ClaimResponse claimResponse =
-        (ClaimResponse) App.FHIR_CTX.newXmlParser().parseResource(body);
+    ClaimResponse claimResponse = (ClaimResponse) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(claimResponse);
 
     // Validate the response.
@@ -166,8 +155,7 @@ public class ClaimResponseEndpointTest {
 
     // Test that non-existent ClaimResponse returns 404.
     Request request = new Request.Builder()
-        .url(base + "/ClaimResponse?identifier=ClaimResponseThatDoesNotExist&patient.identifier=45")
-        .build();
+        .url(base + "/ClaimResponse?identifier=ClaimResponseThatDoesNotExist&patient.identifier=45").build();
     Response response = client.newCall(request).execute();
     Assert.assertEquals(404, response.code());
   }

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimResponseEndpointTest.java
@@ -38,7 +38,7 @@ public class ClaimResponseEndpointTest {
     Path fixture = modulesFolder.resolve("claimresponse-minimal.json");
     FileInputStream inputStream = new FileInputStream(fixture.toString());
     ClaimResponse claimResponse = (ClaimResponse) App.FHIR_CTX.newJsonParser().parseResource(inputStream);
-    String[] claimResponseValues = { "minimal", "1", Database.getStatusFromResource(claimResponse) };
+    String[] claimResponseValues = { "minimal", "minimal", "1", Database.getStatusFromResource(claimResponse) };
     App.DB.write(Database.CLAIM_RESPONSE, Database.CLAIM_RESPONSE_KEYS, claimResponseValues, claimResponse);
   }
 


### PR DESCRIPTION
Supports cancelling a Claim by submitting a Claim with the status `cancelled`. Checks the Claim already exists and can be cancelled.

Updated Database to support this by including an ` update` method. For now this only updates a single column in the row.

Generalized the `write` method to take in keys and values.