### PR TITLE
Spring CORS Headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ bin
 database.mv.db
 database.trace.db
 
+# Ignore the certificates
+*.crt
+
 # Ignore Mac OS X
 **/.DS_Store

--- a/Dockerfile.mitre
+++ b/Dockerfile.mitre
@@ -1,0 +1,10 @@
+FROM gradle:jdk11
+EXPOSE 9000/tcp
+COPY --chown=gradle:gradle . /prior-auth/
+RUN keytool -import -alias mitre_ba_root -file "/prior-auth/MITRE BA Root.crt" \
+    -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit -noprompt -trustcacerts
+RUN keytool -import -alias mitre_ba_npe_ca3 -file "/prior-auth/MITRE BA NPE CA-3.crt" \
+    -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit -noprompt -trustcacerts
+WORKDIR /prior-auth/
+RUN gradle installBootDist
+CMD ["gradle", "bootRun"]

--- a/README.md
+++ b/README.md
@@ -278,6 +278,15 @@ Run the docker image:
 docker run -p 9000:9000 -it --rm --name davinci-prior-auth hspc/davinci-prior-auth:latest
 ```
 
+If you are building the docker image locally from a MITRE machine you must copy over the BA Certificates to the Docker image. Download the `MITRE BA NPE CA-3` and `MITRE BA ROOT` certs from the [MII](http://www2.mitre.org/tech/mii/pki/). Copy the two files to the root directory of this project.
+
+Build and run using:
+
+```
+docker build -f Dockerfile.mitre -t mitre/davinci-prior-auth .
+docker run -p 9000:9000 -it --rm --name davinci-prior-auth mitre/davinci-prior-auth
+```
+
 ## Questions and Contributions
 
 Questions about the project can be asked in the [DaVinci stream on the FHIR Zulip Chat](https://chat.fhir.org/#narrow/stream/179283-DaVinci).

--- a/src/main/java/org/hl7/davinci/priorauth/BundleEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/BundleEndpoint.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,7 @@ import org.hl7.davinci.priorauth.Endpoint.RequestType;
 /**
  * The Bundle endpoint to READ, SEARCH for, and DELETE submitted Bundles.
  */
+@CrossOrigin
 @RestController
 @RequestMapping("/Bundle")
 public class BundleEndpoint {

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -260,11 +260,14 @@ public class ClaimEndpoint {
       }
 
       // generate random responses since not cancelling
-      switch (getRand(3)) {
+      switch (getRand(6)) {
       case 1:
         responseDisposition = "Granted";
         break;
       case 2:
+      case 3:
+      case 4:
+      case 5:
         responseDisposition = "Pending";
 
         switch (getRand(2)) {
@@ -278,7 +281,7 @@ public class ClaimEndpoint {
 
         delayedUpdate = true;
         break;
-      case 3:
+      case 6:
       default:
         responseDisposition = "Denied";
         break;

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,6 +57,7 @@ import okhttp3.Request;
 /**
  * The Claim endpoint to READ, SEARCH for, and DELETE submitted claims.
  */
+@CrossOrigin
 @RestController
 @RequestMapping("/Claim")
 public class ClaimEndpoint {
@@ -177,7 +179,7 @@ public class ClaimEndpoint {
     MediaType contentType = requestType == RequestType.JSON ? MediaType.APPLICATION_JSON : MediaType.APPLICATION_XML;
     return ResponseEntity.status(status).contentType(contentType)
         .header(HttpHeaders.LOCATION, uri + "ClaimResponse?identifier=" + id + "&patient.identifier=" + patient)
-        .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body(formattedData);
+        .body(formattedData);
 
   }
 
@@ -259,15 +261,13 @@ public class ClaimEndpoint {
         processClaimItems(claim, id, relatedId);
       }
 
-      // generate random responses since not cancelling
+      // Generate random responses since not cancelling
+      // with a 4 in 6 chance of being pending
       switch (getRand(6)) {
       case 1:
-        responseDisposition = "Granted";
-        break;
       case 2:
       case 3:
       case 4:
-      case 5:
         responseDisposition = "Pending";
 
         switch (getRand(2)) {
@@ -280,6 +280,9 @@ public class ClaimEndpoint {
         }
 
         delayedUpdate = true;
+        break;
+      case 5:
+        responseDisposition = "Granted";
         break;
       case 6:
       default:

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimResponseEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimResponseEndpoint.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +20,7 @@ import org.hl7.davinci.priorauth.Endpoint.RequestType;
  * The ClaimResponse endpoint to READ, SEARCH for, and DELETE ClaimResponses to
  * submitted claims.
  */
+@CrossOrigin
 @RestController
 @RequestMapping("/ClaimResponse")
 public class ClaimResponseEndpoint {

--- a/src/main/java/org/hl7/davinci/priorauth/DebugEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/DebugEndpoint.java
@@ -8,10 +8,10 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +22,7 @@ import org.hl7.fhir.r4.model.ClaimResponse;
 
 import ca.uhn.fhir.context.FhirContext;
 
+@CrossOrigin
 @RestController
 @RequestMapping("/debug")
 public class DebugEndpoint {
@@ -97,8 +98,7 @@ public class DebugEndpoint {
     }
 
     logger.info("DebugEndpoint::Prepopulating database complete");
-    return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON)
-        .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body(responseData);
+    return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(responseData);
   }
 
   private static Bundle getResource(String fileName) throws FileNotFoundException {
@@ -151,10 +151,10 @@ public class DebugEndpoint {
   private ResponseEntity<String> query(String resource) {
     logger.info("GET /debug/" + resource);
     if (App.debugMode) {
-      return new ResponseEntity<>(App.getDB().generateAndRunQuery(resource), Endpoint.corsHeader(), HttpStatus.OK);
+      return new ResponseEntity<>(App.getDB().generateAndRunQuery(resource), HttpStatus.OK);
     } else {
       logger.warning("DebugEndpoint::query disabled");
-      return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.BAD_REQUEST);
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/DebugEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/DebugEndpoint.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -96,7 +97,8 @@ public class DebugEndpoint {
     }
 
     logger.info("DebugEndpoint::Prepopulating database complete");
-    return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(responseData);
+    return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON)
+        .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body(responseData);
   }
 
   private static Bundle getResource(String fileName) throws FileNotFoundException {
@@ -149,10 +151,10 @@ public class DebugEndpoint {
   private ResponseEntity<String> query(String resource) {
     logger.info("GET /debug/" + resource);
     if (App.debugMode) {
-      return new ResponseEntity<>(App.getDB().generateAndRunQuery(resource), HttpStatus.OK);
+      return new ResponseEntity<>(App.getDB().generateAndRunQuery(resource), Endpoint.corsHeader(), HttpStatus.OK);
     } else {
       logger.warning("DebugEndpoint::query disabled");
-      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+      return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
@@ -9,10 +9,8 @@ import org.hl7.fhir.r4.model.Claim;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
 
 public class Endpoint {
 
@@ -40,7 +38,7 @@ public class Endpoint {
         logger.info("GET /" + resourceType + ":" + constraintMap.toString() + " fhir+" + requestType.name());
         if (!constraintMap.containsKey("patient")) {
             logger.warning("Endpoint::read:patient null");
-            return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
         String formattedData = null;
         if ((!constraintMap.containsKey("id") || constraintMap.get("id") == null)
@@ -58,7 +56,7 @@ public class Endpoint {
             baseResource = App.getDB().read(resourceType, constraintMap);
 
             if (baseResource == null)
-                return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.NOT_FOUND);
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
 
             // Convert to correct resourceType
             if (resourceType == Database.BUNDLE) {
@@ -73,10 +71,10 @@ public class Endpoint {
                         : App.getDB().xml(bundleResponse);
             } else {
                 logger.warning("Endpoint::read:invalid resourceType: " + resourceType);
-                return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.BAD_REQUEST);
+                return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
             }
         }
-        return new ResponseEntity<String>(formattedData, Endpoint.corsHeader(), HttpStatus.OK);
+        return new ResponseEntity<String>(formattedData, HttpStatus.OK);
     }
 
     /**
@@ -109,17 +107,7 @@ public class Endpoint {
             outcome = FhirUtils.buildOutcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
         }
         String formattedData = requestType == RequestType.JSON ? App.getDB().json(outcome) : App.getDB().xml(outcome);
-        return new ResponseEntity<>(formattedData, Endpoint.corsHeader(), status);
+        return new ResponseEntity<>(formattedData, status);
     }
 
-    /**
-     * Get the cors headers
-     * 
-     * @return MultiValueMap with Access-Control-Allow-Origins set to *
-     */
-    public static MultiValueMap<String, String> corsHeader() {
-        MultiValueMap<String, String> headers = new HttpHeaders();
-        headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-        return headers;
-    }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
@@ -40,7 +40,7 @@ public class Endpoint {
         logger.info("GET /" + resourceType + ":" + constraintMap.toString() + " fhir+" + requestType.name());
         if (!constraintMap.containsKey("patient")) {
             logger.warning("Endpoint::read:patient null");
-            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.UNAUTHORIZED);
         }
         String formattedData = null;
         if ((!constraintMap.containsKey("id") || constraintMap.get("id") == null)
@@ -58,7 +58,7 @@ public class Endpoint {
             baseResource = App.getDB().read(resourceType, constraintMap);
 
             if (baseResource == null)
-                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+                return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.NOT_FOUND);
 
             // Convert to correct resourceType
             if (resourceType == Database.BUNDLE) {
@@ -73,12 +73,10 @@ public class Endpoint {
                         : App.getDB().xml(bundleResponse);
             } else {
                 logger.warning("Endpoint::read:invalid resourceType: " + resourceType);
-                return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+                return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.BAD_REQUEST);
             }
         }
-        MultiValueMap<String, String> headers = new HttpHeaders();
-        headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-        return new ResponseEntity<String>(formattedData, headers, HttpStatus.OK);
+        return new ResponseEntity<String>(formattedData, Endpoint.corsHeader(), HttpStatus.OK);
     }
 
     /**
@@ -111,6 +109,17 @@ public class Endpoint {
             outcome = FhirUtils.buildOutcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
         }
         String formattedData = requestType == RequestType.JSON ? App.getDB().json(outcome) : App.getDB().xml(outcome);
-        return new ResponseEntity<>(formattedData, status);
+        return new ResponseEntity<>(formattedData, Endpoint.corsHeader(), status);
+    }
+
+    /**
+     * Get the cors headers
+     * 
+     * @return MultiValueMap with Access-Control-Allow-Origins set to *
+     */
+    public static MultiValueMap<String, String> corsHeader() {
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+        return headers;
     }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
@@ -2,14 +2,15 @@ package org.hl7.davinci.priorauth;
 
 import java.util.logging.Logger;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin
 @RestController
 @RequestMapping("/$expunge")
 public class ExpungeOperation {
@@ -41,11 +42,10 @@ public class ExpungeOperation {
       App.getDB().delete(Database.CLAIM_ITEM);
       App.getDB().delete(Database.CLAIM_RESPONSE);
       App.getDB().delete(Database.SUBSCRIPTION);
-      return ResponseEntity.ok().header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body("Expunge success!");
+      return ResponseEntity.ok().body("Expunge success!");
     } else {
       logger.warning("ExpungeOperation::expungeDatabase:query disabled");
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-          .body("Expunge operation disabled");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Expunge operation disabled");
     }
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
@@ -2,6 +2,7 @@ package org.hl7.davinci.priorauth;
 
 import java.util.logging.Logger;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,10 +41,11 @@ public class ExpungeOperation {
       App.getDB().delete(Database.CLAIM_ITEM);
       App.getDB().delete(Database.CLAIM_RESPONSE);
       App.getDB().delete(Database.SUBSCRIPTION);
-      return ResponseEntity.ok().body("Expunge success!");
+      return ResponseEntity.ok().header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body("Expunge success!");
     } else {
       logger.warning("ExpungeOperation::expungeDatabase:query disabled");
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Expunge operation disabled");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+          .body("Expunge operation disabled");
     }
   }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/LogEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/LogEndpoint.java
@@ -8,10 +8,12 @@ import java.util.logging.Logger;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin
 @RestController
 @RequestMapping("/Log")
 public class LogEndpoint {
@@ -23,10 +25,10 @@ public class LogEndpoint {
         logger.info("GET /Log");
         try {
             String log = new String(Files.readAllBytes(Paths.get(PALogger.getLogPath())));
-            return new ResponseEntity<>(log, Endpoint.corsHeader(), HttpStatus.OK);
+            return new ResponseEntity<>(log, HttpStatus.OK);
         } catch (IOException e) {
             logger.log(Level.SEVERE, "LogEndpoint::IOException", e);
-            return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/LogEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/LogEndpoint.java
@@ -23,10 +23,10 @@ public class LogEndpoint {
         logger.info("GET /Log");
         try {
             String log = new String(Files.readAllBytes(Paths.get(PALogger.getLogPath())));
-            return new ResponseEntity<>(log, HttpStatus.OK);
+            return new ResponseEntity<>(log, Endpoint.corsHeader(), HttpStatus.OK);
         } catch (IOException e) {
             logger.log(Level.SEVERE, "LogEndpoint::IOException", e);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(Endpoint.corsHeader(), HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/org/hl7/davinci/priorauth/Metadata.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Metadata.java
@@ -13,11 +13,10 @@ import org.hl7.fhir.r4.model.CapabilityStatement.RestfulCapabilityMode;
 import org.hl7.fhir.r4.model.CapabilityStatement.TypeRestfulInteraction;
 import org.hl7.fhir.r4.model.Enumerations.FHIRVersion;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * The metadata microservice provides a CapabilityStatement.
  */
+@CrossOrigin
 @RestController
 @RequestMapping("/metadata")
 public class Metadata {
@@ -40,9 +40,7 @@ public class Metadata {
       capabilityStatement = buildCapabilityStatement();
     }
     String json = App.getDB().json(capabilityStatement);
-    MultiValueMap<String, String> headers = new HttpHeaders();
-    headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-    return new ResponseEntity<String>(json, headers, HttpStatus.OK);
+    return new ResponseEntity<String>(json, HttpStatus.OK);
   }
 
   @GetMapping(value = "", produces = { MediaType.APPLICATION_XML_VALUE, "application/fhir+xml" })
@@ -51,9 +49,7 @@ public class Metadata {
       capabilityStatement = buildCapabilityStatement();
     }
     String xml = App.getDB().xml(capabilityStatement);
-    MultiValueMap<String, String> headers = new HttpHeaders();
-    headers.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-    return new ResponseEntity<String>(xml, headers, HttpStatus.OK);
+    return new ResponseEntity<String>(xml, HttpStatus.OK);
   }
 
   /**

--- a/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -115,7 +116,8 @@ public class SubscriptionEndpoint {
         }
         MediaType contentType = requestType == RequestType.JSON ? MediaType.APPLICATION_JSON
                 : MediaType.APPLICATION_XML;
-        return ResponseEntity.status(status).contentType(contentType).body(formattedData);
+        return ResponseEntity.status(status).contentType(contentType)
+                .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body(formattedData);
     }
 
     private Subscription processSubscription(Subscription subscription) {

--- a/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
@@ -9,10 +9,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +33,7 @@ import ca.uhn.fhir.parser.IParser;
  * The Subscription endpoint to create new subscriptions or delete outdated
  * ones.
  */
+@CrossOrigin
 @RestController
 @RequestMapping("/Subscription")
 public class SubscriptionEndpoint {
@@ -116,8 +117,7 @@ public class SubscriptionEndpoint {
         }
         MediaType contentType = requestType == RequestType.JSON ? MediaType.APPLICATION_JSON
                 : MediaType.APPLICATION_XML;
-        return ResponseEntity.status(status).contentType(contentType)
-                .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*").body(formattedData);
+        return ResponseEntity.status(status).contentType(contentType).body(formattedData);
     }
 
     private Subscription processSubscription(Subscription subscription) {

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
@@ -9,11 +9,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
@@ -25,10 +35,6 @@ import org.junit.runner.RunWith;
 
 import ca.uhn.fhir.validation.ValidationResult;
 import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = "server.servlet.contextPath=/fhir")
@@ -38,9 +44,14 @@ public class ClaimSubmitTest {
   @LocalServerPort
   private int port;
 
-  public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+  @Autowired
+  private WebApplicationContext wac;
 
-  private static OkHttpClient client;
+  private static ResultMatcher cors = MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*");
+  private static ResultMatcher ok = MockMvcResultMatchers.status().isOk();
+  private static ResultMatcher badRequest = MockMvcResultMatchers.status().isBadRequest();
+
+  public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
   /** List of resource IDs that will need to be cleaned up after the tests */
   private static List<String> resourceIds;
@@ -52,7 +63,6 @@ public class ClaimSubmitTest {
 
   @BeforeClass
   public static void setup() throws IOException {
-    client = new OkHttpClient();
     App.initializeAppDB();
     resourceIds = new ArrayList<String>();
 
@@ -90,17 +100,19 @@ public class ClaimSubmitTest {
   }
 
   @Test
-  public void submitCompleteClaim() throws IOException {
-    String base = "http://localhost:" + port + "/fhir";
-
+  public void submitCompleteClaim() throws Exception {
     // Test that we can POST /fhir/Claim/$submit
-    RequestBody requestBody = RequestBody.create(JSON, completeClaim);
-    Request request = new Request.Builder().addHeader("Content-Type", "application/fhir+json")
-        .url(base + "/Claim/$submit").post(requestBody).build();
-    Response response = client.newCall(request).execute();
+    DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+    MockMvc mockMvc = builder.build();
+    MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/Claim/$submit").content(completeClaim)
+        .header("Content-Type", "application/fhir+json").header("Access-Control-Request-Method", "POST")
+        .header("Origin", "http://localhost:" + port);
+
+    // Test the response has CORS headers and returned status 200
+    MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
 
     // Check Location header if it exists...
-    String location = response.header("Location");
+    String location = mvcresult.getResponse().getHeader("Location");
     if (location != null) {
       int index = location.indexOf("fhir/ClaimResponse/");
       if (index >= 0) {
@@ -108,15 +120,8 @@ public class ClaimSubmitTest {
       }
     }
 
-    // Check that the claim succeeded
-    Assert.assertEquals(200, response.code());
-
-    // Test the response has CORS headers
-    String cors = response.header("Access-Control-Allow-Origin");
-    Assert.assertEquals("*", cors);
-
     // Test the response is a JSON Bundle
-    String responseBody = response.body().string();
+    String responseBody = mvcresult.getResponse().getContentAsString();
     Bundle bundleResponse = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(responseBody);
     Assert.assertNotNull(bundleResponse);
 
@@ -138,35 +143,38 @@ public class ClaimSubmitTest {
   }
 
   @Test
-  public void submitEmptyBundle() throws IOException {
+  public void submitEmptyBundle() throws Exception {
     checkErrors(emptyBundle);
   }
 
   @Test
-  public void submitClaimOnly() throws IOException {
+  public void submitClaimOnly() throws Exception {
     checkErrors(claimOnly);
   }
 
   @Test
-  public void submitBundleWithOnlyClaim() throws IOException {
+  public void submitBundleWithOnlyClaim() throws Exception {
     checkErrors(bundleWithOnlyClaim);
   }
 
-  private void checkErrors(String body) throws IOException {
-    String base = "http://localhost:" + port + "/fhir";
-
+  private void checkErrors(String body) throws Exception {
     // Test that we can POST /fhir/Claim/$submit
-    RequestBody requestBody = RequestBody.create(JSON, body);
-    Request request = new Request.Builder().url(base + "/Claim/$submit").post(requestBody).build();
-    Response response = client.newCall(request).execute();
-    Assert.assertEquals(400, response.code());
+    // RequestBody requestBody = RequestBody.create(JSON, body);
+    // Request request = new Request.Builder().url(base +
+    // "/Claim/$submit").post(requestBody).build();
+    // Response response = client.newCall(request).execute();
 
-    // Test the response has CORS headers
-    String cors = response.header("Access-Control-Allow-Origin");
-    Assert.assertEquals("*", cors);
+    DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+    MockMvc mockMvc = builder.build();
+    MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/Claim/$submit").content(body)
+        .header("Content-Type", "application/fhir+json").header("Access-Control-Request-Method", "POST")
+        .header("Origin", "http://localhost:" + port);
 
-    // Test the response is a JSON OperationOutcome
-    String responseBody = response.body().string();
+    // Test the response has CORS headers and returned status 400
+    MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(badRequest).andExpect(cors).andReturn();
+
+    // Test the response is a JSON Operation Outcome
+    String responseBody = mvcresult.getResponse().getContentAsString();
     OperationOutcome error = (OperationOutcome) App.FHIR_CTX.newJsonParser().parseResource(responseBody);
     Assert.assertNotNull(error);
 


### PR DESCRIPTION
Changes for the Prior Auth Client in DTR to work - almost all of the changes are adding Access-Control-Allow-Origin *

Also increased the probability of pending result for testing (since almost everything we show off has to do with pended Claims)

Covers PriorAuth 39: https://jira.mitre.org/browse/PRIORAUTH-39