### PR TITLE
Catch DELETE error and report back

### DIFF
--- a/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Endpoint.java
@@ -25,6 +25,7 @@ public class Endpoint {
     static String REQUIRES_ID = "Instance ID is required: DELETE {resourceType}?identifier=";
     static String REQUIRES_PATIENT = "Patient Identifier is required: DELETE {resourceType}?patient.identifier=";
     static String DELETED_MSG = "Deleted resource and all related and referenced resources.";
+    static String SQL_ERROR = "Unable to perform operation. SQL error while processing. Check logs for more details.";
 
     /**
      * Read a resource from an endpoint in either JSON or XML
@@ -103,8 +104,10 @@ public class Endpoint {
             outcome = FhirUtils.buildOutcome(IssueSeverity.ERROR, IssueType.REQUIRED, REQUIRES_PATIENT);
         } else {
             // Delete the specified resource..
-            App.getDB().delete(resourceType, id, patient);
-            outcome = FhirUtils.buildOutcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
+            if (App.getDB().delete(resourceType, id, patient))
+                outcome = FhirUtils.buildOutcome(IssueSeverity.INFORMATION, IssueType.DELETED, DELETED_MSG);
+            else
+                outcome = FhirUtils.buildOutcome(IssueSeverity.ERROR, IssueType.INCOMPLETE, SQL_ERROR);
         }
         String formattedData = FhirUtils.getFormattedData(outcome, requestType);
         return new ResponseEntity<>(formattedData, status);


### PR DESCRIPTION
Bug fix for [PRIORAUTH-38](https://jira.mitre.org/projects/PRIORAUTH/issues/PRIORAUTH-38?filter=allopenissues).

Original solution was to have Subscription cascade on delete. This fixes the issue but then a Subscription could be deleted before the subscriber is notified. Instead the error is caught and if the delete fails the OperationOutcome states the delete was unable to occur.