### PR TITLE
Partial Approval

### DIFF
--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -28,6 +28,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.hl7.davinci.priorauth.Endpoint.RequestType;
+import org.hl7.davinci.priorauth.FhirUtils.Disposition;
+import org.hl7.davinci.priorauth.FhirUtils.ReviewAction;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Claim;
@@ -74,45 +76,6 @@ public class ClaimEndpoint {
   String ITEM_REFERENCE_EXTENSION_URL = "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-itemReference";
   String REVIEW_ACTION_EXTENSION_URL = "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewAction";
   String REVIEW_ACTION_REASON_EXTENSION_URL = "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewActionReason";
-
-  /**
-   * Enum for the ClaimResponse Disposition field Values are Granted, Denied,
-   * Partial, Pending, and Cancelled
-   */
-  public enum Disposition {
-    GRANTED("Granted"), DENIED("Denied"), PARTIAL("Partial"), PENDING("Pending"), CANCELLED("Cancelled"),
-    UNKNOWN("Unknown");
-
-    private final String value;
-
-    Disposition(String value) {
-      this.value = value;
-    }
-
-    public String value() {
-      return this.value;
-    }
-  }
-
-  /**
-   * Enum for the ClaimResponse.item reviewAction extensions used for X12 HCR01
-   * Responde Code. Codes taken from X12 and CMS
-   * http://www.x12.org/x12org/subcommittees/X12N/N0210_4010MultProcedures.pdf
-   * https://www.cms.gov/Research-Statistics-Data-and-Systems/Computer-Data-and-Systems/ESMD/Downloads/esMD_X12_278_09_2016Companion_Guide.pdf
-   */
-  public enum ReviewAction {
-    APPROVED("A1"), PARTIAL("A2"), DENIED("A3"), PENDED("A4"), CANCELLED("A6");
-
-    private final String value;
-
-    ReviewAction(String value) {
-      this.value = value;
-    }
-
-    public StringType value() {
-      return new StringType(this.value);
-    }
-  }
 
   @GetMapping(value = "", produces = { MediaType.APPLICATION_JSON_VALUE, "application/fhir+json" })
   public ResponseEntity<String> readClaimJson(HttpServletRequest request,

--- a/src/main/java/org/hl7/davinci/priorauth/CreateDatabase.sql
+++ b/src/main/java/org/hl7/davinci/priorauth/CreateDatabase.sql
@@ -30,6 +30,7 @@ BEGIN TRANSACTION;
     CREATE TABLE IF NOT EXISTS ClaimItem (
         "id" varchar,
         "sequence" varchar,
+        "outcome" varchar DEFAULT NULL,
         "status" varchar,
         "timestamp" datetime DEFAULT CURRENT_TIMESTAMP,
         CONSTRAINT pk_claimitems PRIMARY KEY ("id", "sequence"),

--- a/src/main/java/org/hl7/davinci/priorauth/CreateDatabase.sql
+++ b/src/main/java/org/hl7/davinci/priorauth/CreateDatabase.sql
@@ -22,6 +22,7 @@ BEGIN TRANSACTION;
         "claimId" varchar,
         "patient" varchar,
         "status" varchar,
+        "outcome" varchar,
         "timestamp" datetime DEFAULT CURRENT_TIMESTAMP,
         "resource" clob,
         FOREIGN KEY ("claimId") REFERENCES Claim("id") ON DELETE CASCADE

--- a/src/main/java/org/hl7/davinci/priorauth/Database.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Database.java
@@ -381,10 +381,9 @@ public class Database {
   /**
    * Update a single column in a row to a new value
    * 
-   * @param resourceType - the resource type.
-   * @param id           - the resource id.
-   * @param column       - the name of the column to update.
-   * @param value        - the new value.
+   * @param resourceType     - the resource type.
+   * @param constraintParams - map of column to value for the SQL WHERE clause
+   * @param data             - map of column to value for the SQL SET clause
    * @return boolean - whether or not the update was successful
    */
   public boolean update(String resourceType, Map<String, Object> constraintParams, Map<String, Object> data) {

--- a/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
+++ b/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
@@ -3,6 +3,8 @@ package org.hl7.davinci.priorauth;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.hl7.davinci.priorauth.ClaimEndpoint.Disposition;
+import org.hl7.davinci.priorauth.ClaimEndpoint.ReviewAction;
 import org.hl7.davinci.priorauth.Endpoint.RequestType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
@@ -72,6 +74,27 @@ public class FhirUtils {
       logger.log(Level.SEVERE, "FhirUtils::getPatientIdFromResource(error processing patient)", e);
     }
     return patient;
+  }
+
+  /**
+   * Convert the response disposition into a review action
+   * 
+   * @param disposition - the response disposition
+   * @return corresponding ReviewAction for the Disposition
+   */
+  public static ReviewAction dispositionToReviewAction(Disposition disposition) {
+    if (disposition == Disposition.DENIED)
+      return ReviewAction.DENIED;
+    else if (disposition == Disposition.GRANTED)
+      return ReviewAction.APPROVED;
+    else if (disposition == Disposition.PARTIAL)
+      return ReviewAction.PARTIAL;
+    else if (disposition == Disposition.PENDING)
+      return ReviewAction.PENDED;
+    else if (disposition == Disposition.CANCELLED)
+      return ReviewAction.CANCELLED;
+    else
+      return null;
   }
 
   /**

--- a/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
+++ b/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
@@ -3,8 +3,6 @@ package org.hl7.davinci.priorauth;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.hl7.davinci.priorauth.ClaimEndpoint.Disposition;
-import org.hl7.davinci.priorauth.ClaimEndpoint.ReviewAction;
 import org.hl7.davinci.priorauth.Endpoint.RequestType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
@@ -12,6 +10,7 @@ import org.hl7.fhir.r4.model.Claim;
 import org.hl7.fhir.r4.model.ClaimResponse;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Claim.ClaimStatus;
 import org.hl7.fhir.r4.model.Subscription.SubscriptionStatus;
@@ -19,6 +18,45 @@ import org.hl7.fhir.r4.model.Subscription.SubscriptionStatus;
 public class FhirUtils {
 
   static final Logger logger = PALogger.getLogger();
+
+  /**
+   * Enum for the ClaimResponse Disposition field Values are Granted, Denied,
+   * Partial, Pending, and Cancelled
+   */
+  public enum Disposition {
+    GRANTED("Granted"), DENIED("Denied"), PARTIAL("Partial"), PENDING("Pending"), CANCELLED("Cancelled"),
+    UNKNOWN("Unknown");
+
+    private final String value;
+
+    Disposition(String value) {
+      this.value = value;
+    }
+
+    public String value() {
+      return this.value;
+    }
+  }
+
+  /**
+   * Enum for the ClaimResponse.item reviewAction extensions used for X12 HCR01
+   * Responde Code. Codes taken from X12 and CMS
+   * http://www.x12.org/x12org/subcommittees/X12N/N0210_4010MultProcedures.pdf
+   * https://www.cms.gov/Research-Statistics-Data-and-Systems/Computer-Data-and-Systems/ESMD/Downloads/esMD_X12_278_09_2016Companion_Guide.pdf
+   */
+  public enum ReviewAction {
+    APPROVED("A1"), PARTIAL("A2"), DENIED("A3"), PENDED("A4"), CANCELLED("A6");
+
+    private final String value;
+
+    ReviewAction(String value) {
+      this.value = value;
+    }
+
+    public StringType value() {
+      return new StringType(this.value);
+    }
+  }
 
   /**
    * Internal function to get the correct status from a resource depending on the


### PR DESCRIPTION
Support for partial approvals (when a Claim has multiple items and some are approved, some are denied). Required some restructuring of the original code to support enums for the disposition.

Includes some X12 extensions required by the IG.