### PR TITLE
Ensure fullUrl and Identifiers echoed back are the same

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compile 'org.webjars:bootstrap:3.3.7'
     compile 'org.webjars:jquery:3.1.0'
     compile 'com.squareup.okhttp3:okhttp:3.14.1'
+    compile 'com.googlecode.json-simple:json-simple:1.1.1'
 
     implementation 'com.google.guava:guava:27.0.1-jre'
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:3.7.0'

--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -243,7 +243,6 @@ public class ClaimEndpoint {
 
       // Store the bundle...
       bundle.setId(id);
-      bundle = FhirUtils.setBundleFullUrls(bundle);
       Map<String, Object> bundleMap = new HashMap<String, Object>();
       bundleMap.put("id", id);
       bundleMap.put("patient", patient);
@@ -557,11 +556,10 @@ public class ClaimEndpoint {
     responseBundle.setType(Bundle.BundleType.COLLECTION);
     BundleEntryComponent responseEntry = responseBundle.addEntry();
     responseEntry.setResource(response);
-    responseEntry.setFullUrl(App.getBaseUrl() + "/Bundle/" + id);
+    responseEntry.setFullUrl(App.getBaseUrl() + "/ClaimResponse/" + id);
     for (BundleEntryComponent entry : bundle.getEntry()) {
       responseBundle.addEntry(entry);
     }
-    responseBundle = FhirUtils.setBundleFullUrls(responseBundle);
 
     // Store the claim respnose...
     Map<String, Object> responseMap = new HashMap<String, Object>();

--- a/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
+++ b/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
@@ -75,20 +75,6 @@ public class FhirUtils {
   }
 
   /**
-   * Set the fullUrl on each entry of a bundle
-   * 
-   * @param bundle - the bundle to modify fullUrls for
-   * @return the same bundle with each fullUrl set appropriately
-   */
-  public static Bundle setBundleFullUrls(Bundle bundle) {
-    for (BundleEntryComponent entry : bundle.getEntry()) {
-      entry.setFullUrl(App.getBaseUrl() + "/" + entry.getResource().getResourceType() + "/"
-          + getIdFromResource(entry.getResource()));
-    }
-    return bundle;
-  }
-
-  /**
    * Find the first instance of a ClaimResponse in a bundle
    * 
    * @param bundle - the bundle search through for the ClaimResponse
@@ -102,6 +88,23 @@ public class FhirUtils {
     }
 
     return claimResponse;
+  }
+
+  /**
+   * Find the BundleEntryComponent in a Bundle where the resource has the desired
+   * id
+   * 
+   * @param bundle - the bundle to search through
+   * @param id     - the resource id to match
+   * @return BundleEntryComponent in Bundle with resource matching id
+   */
+  public static BundleEntryComponent getEntryComponentFromBundle(Bundle bundle, String id) {
+    for (BundleEntryComponent entry : bundle.getEntry()) {
+      if (entry.getResource().getId().equals(id)) {
+        return entry;
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
@@ -27,6 +27,11 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -124,6 +129,33 @@ public class ClaimSubmitTest {
     String responseBody = mvcresult.getResponse().getContentAsString();
     Bundle bundleResponse = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(responseBody);
     Assert.assertNotNull(bundleResponse);
+
+    // Make sure all fullUrls and identifiers on the bundleResponse are the same as
+    // the submitted Claim
+    Bundle claimBundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(completeClaim);
+    for (BundleEntryComponent responseEntry : bundleResponse.getEntry()) {
+      if (responseEntry.getResource().getResourceType() != ResourceType.ClaimResponse) {
+        String id = responseEntry.getResource().getId();
+        BundleEntryComponent claimEntry = FhirUtils.getEntryComponentFromBundle(claimBundle, id);
+        if (claimEntry != null) {
+          Assert.assertTrue(responseEntry.getFullUrl().equals(claimEntry.getFullUrl()));
+
+          // Make sure the identifiers present in the request are still present in the
+          // response
+          String claimResource = FhirUtils.json(claimEntry.getResource());
+          String responseResource = FhirUtils.json(responseEntry.getResource());
+          JSONObject responseJSON = (JSONObject) new JSONParser().parse(responseResource);
+          JSONObject claimJSON = (JSONObject) new JSONParser().parse(claimResource);
+          if (claimJSON.get("identifier") != null) {
+            JSONArray claimIdentifiers = (JSONArray) claimJSON.get("identifier");
+            JSONArray responseIdentifiers = (JSONArray) responseJSON.get("identifier");
+            for (int i = 0; i < claimIdentifiers.size(); i++) {
+              Assert.assertTrue(responseIdentifiers.contains(claimIdentifiers.get(i)));
+            }
+          }
+        }
+      }
+    }
 
     // Make sure we clean up afterwards...
     String id = FhirUtils.getIdFromResource(bundleResponse);


### PR DESCRIPTION
PRIORAUTH-47: “When echoing back resources that are the same as were present in the prior authorization request, the server SHALL ensure that the same fullUrl and resource identifiers are used in the response as appeared in the request"
