### PR TITLE
REST Updates

### DIFF
--- a/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimEndpoint.java
@@ -60,6 +60,7 @@ import org.hl7.fhir.r4.model.Claim.ItemComponent;
 import ca.uhn.fhir.parser.IParser;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 
 /**
  * The Claim endpoint to READ, SEARCH for, and DELETE submitted claims.
@@ -733,6 +734,7 @@ public class ClaimEndpoint {
         // Send notification to each subscriber
         subscriptions.stream().forEach(resource -> {
           Subscription subscription = (Subscription) resource;
+          String subscriptionId = FhirUtils.getIdFromResource(subscription);
           SubscriptionChannelType subscriptionType = subscription.getChannel().getType();
           if (subscriptionType == SubscriptionChannelType.RESTHOOK) {
             // Send rest-hook notification...
@@ -740,20 +742,26 @@ public class ClaimEndpoint {
             logger.info("SubscriptionHandler::Sending rest-hook notification to " + endpoint);
             try {
               OkHttpClient client = new OkHttpClient();
-              okhttp3.Response response = client.newCall(new Request.Builder().url(endpoint).build()).execute();
+              okhttp3.Response response = client
+                  .newCall(new Request.Builder().post(RequestBody.create(null, "")).url(endpoint).build()).execute();
               logger.fine("SubscriptionHandler::Response " + response.code());
+              App.getDB().update(Table.SUBSCRIPTION, Collections.singletonMap("id", subscriptionId),
+                  Collections.singletonMap("status", SubscriptionStatus.ACTIVE.getDisplay().toLowerCase()));
             } catch (IOException e) {
               logger.log(Level.SEVERE, "SubscriptionHandler::IOException in request", e);
+              App.getDB().update(Table.SUBSCRIPTION, Collections.singletonMap("id", subscriptionId),
+                  Collections.singletonMap("status", SubscriptionStatus.ERROR.getDisplay().toLowerCase()));
             }
           } else if (subscriptionType == SubscriptionChannelType.WEBSOCKET) {
             // Send websocket notification...
-            String subscriptionId = FhirUtils.getIdFromResource(subscription);
             String websocketId = App.getDB().readString(Table.SUBSCRIPTION,
                 Collections.singletonMap("id", subscriptionId), "websocketId");
             if (websocketId != null) {
               logger.info("SubscriptionHandler::Sending web-socket notification to " + websocketId);
               SubscribeController.sendMessageToUser(websocketId, WebSocketConfig.SUBSCRIBE_USER_NOTIFICATION,
                   "ping: " + subscriptionId);
+              App.getDB().update(Table.SUBSCRIPTION, Collections.singletonMap("id", subscriptionId),
+                  Collections.singletonMap("status", SubscriptionStatus.ACTIVE.getDisplay().toLowerCase()));
             } else {
               logger.severe("SubscriptionHandler::Unable to send web-socket notification for subscription "
                   + subscriptionId + " because web-socket id is null. Client did not bind a websocket to id");

--- a/src/main/java/org/hl7/davinci/priorauth/DebugEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/DebugEndpoint.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.hl7.davinci.priorauth.Database.Table;
@@ -54,7 +55,7 @@ public class DebugEndpoint {
     return query(Table.SUBSCRIPTION);
   }
 
-  @GetMapping("/PopulateDatabaseTestData")
+  @PostMapping("/PopulateDatabaseTestData")
   public ResponseEntity<String> populateDatabase() {
     if (App.debugMode)
       return populateDB();

--- a/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
@@ -6,7 +6,6 @@ import org.hl7.davinci.priorauth.Database.Table;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class ExpungeOperation {
 
   static final Logger logger = PALogger.getLogger();
-
-  @GetMapping("")
-  public ResponseEntity<String> getExpunge() {
-    return expungeDatabase();
-  }
 
   @PostMapping("")
   public ResponseEntity<String> postExpunge() {
@@ -35,7 +29,7 @@ public class ExpungeOperation {
    * @return - HTTP 200
    */
   private ResponseEntity<String> expungeDatabase() {
-    logger.info("GET/POST /$expunge");
+    logger.info("POST /$expunge");
     if (App.debugMode) {
       // Cascading delete of everything...
       App.getDB().delete(Table.BUNDLE);

--- a/src/main/java/org/hl7/davinci/priorauth/Metadata.java
+++ b/src/main/java/org/hl7/davinci/priorauth/Metadata.java
@@ -3,6 +3,7 @@ package org.hl7.davinci.priorauth;
 import java.util.Calendar;
 
 import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementImplementationComponent;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementKind;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestComponent;
@@ -78,6 +79,8 @@ public class Metadata {
     metadata.setFhirVersion(FHIRVersion._4_0_0);
     metadata.addFormat("json");
     metadata.addFormat("xml");
+    metadata.addExtension("http://hl7.org/fhir/StructureDefinition/capabilitystatement-websocket",
+        new StringType("/fhir"));
     metadata.addImplementationGuide("https://build.fhir.org/ig/HL7/davinci-pas/index.html");
     metadata
         .addImplementationGuide("http://wiki.hl7.org/index.php?title=Da_Vinci_Prior_Authorization_FHIR_IG_Proposal");

--- a/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
@@ -9,12 +9,15 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +30,7 @@ import org.hl7.fhir.r4.model.Subscription;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
 import org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType;
+import org.hl7.fhir.r4.model.Subscription.SubscriptionStatus;
 
 import ca.uhn.fhir.parser.IParser;
 
@@ -45,6 +49,26 @@ public class SubscriptionEndpoint {
     String SUBSCRIPTION_ADDED_SUCCESS = "Subscription successful";
     String PROCESS_FAILED = "Unable to process the request properly. Check the log for more details.";
     String INVALID_CHANNEL_TYPE = "Invalid channel type. Must be rest-hook or websocket";
+
+    @GetMapping(value = "", produces = { MediaType.APPLICATION_JSON_VALUE, "application/fhir+json" })
+    public ResponseEntity<String> readSubscriptionJSON(HttpServletRequest request,
+            @RequestParam(name = "identifier", required = false) String id,
+            @RequestParam(name = "patient.identifier") String patient) {
+        Map<String, Object> constraintMap = new HashMap<String, Object>();
+        constraintMap.put("claimResponseId", id);
+        constraintMap.put("patient", patient);
+        return Endpoint.read(Table.SUBSCRIPTION, constraintMap, request, RequestType.JSON);
+    }
+
+    @GetMapping(value = "", produces = { MediaType.APPLICATION_XML_VALUE, "application/fhir+xml" })
+    public ResponseEntity<String> readSubscriptionXML(HttpServletRequest request,
+            @RequestParam(name = "identifier", required = false) String id,
+            @RequestParam(name = "patient.identifier") String patient) {
+        Map<String, Object> constraintMap = new HashMap<String, Object>();
+        constraintMap.put("claimResponseId", id);
+        constraintMap.put("patient", patient);
+        return Endpoint.read(Table.SUBSCRIPTION, constraintMap, request, RequestType.XML);
+    }
 
     @PostMapping(value = "", consumes = { MediaType.APPLICATION_JSON_VALUE, "application/fhir+json" })
     public ResponseEntity<String> addSubscriptionJSON(HttpEntity<String> entity) {
@@ -168,6 +192,7 @@ public class SubscriptionEndpoint {
         // Add to db
         String id = UUID.randomUUID().toString();
         subscription.setId(id);
+        subscription.setStatus(SubscriptionStatus.ACTIVE);
         logger.fine("SubscriptionEndpoint::Subscription given uuid " + id);
         Map<String, Object> dataMap = new HashMap<String, Object>();
         dataMap.put("id", id);

--- a/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/BundleEndpointTest.java
@@ -175,7 +175,7 @@ public class BundleEndpointTest {
         .header("Accept", "application/fhir+json").header("Access-Control-Request-Method", "GET")
         .header("Origin", "http://localhost:" + port);
 
-    // Test the response has CORS headers and returned status 200
+    // Test the response has CORS headers and returned status 404
     mockMvc.perform(requestBuilder).andExpect(notFound).andExpect(cors);
   }
 

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimSubmitTest.java
@@ -53,7 +53,7 @@ public class ClaimSubmitTest {
   private WebApplicationContext wac;
 
   private static ResultMatcher cors = MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*");
-  private static ResultMatcher ok = MockMvcResultMatchers.status().isOk();
+  private static ResultMatcher created = MockMvcResultMatchers.status().isCreated();
   private static ResultMatcher badRequest = MockMvcResultMatchers.status().isBadRequest();
 
   public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
@@ -113,8 +113,8 @@ public class ClaimSubmitTest {
         .header("Content-Type", "application/fhir+json").header("Access-Control-Request-Method", "POST")
         .header("Origin", "http://localhost:" + port);
 
-    // Test the response has CORS headers and returned status 200
-    MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
+    // Test the response has CORS headers and returned status 201 (created)
+    MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(created).andExpect(cors).andReturn();
 
     // Check Location header if it exists...
     String location = mvcresult.getResponse().getHeader("Location");

--- a/src/test/java/org/hl7/davinci/priorauth/MetadataTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/MetadataTest.java
@@ -17,6 +17,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -59,6 +61,14 @@ public class MetadataTest {
     CapabilityStatement capabilityStatement = (CapabilityStatement) App.FHIR_CTX.newJsonParser().parseResource(body);
     Assert.assertNotNull(capabilityStatement);
 
+    // Test the websocket extension is included
+    StringType websocketUrl = null;
+    for (Extension ext : capabilityStatement.getExtension()) {
+      if (ext.getUrl().equals("http://hl7.org/fhir/StructureDefinition/capabilitystatement-websocket"))
+        websocketUrl = (StringType) ext.getValue();
+    }
+    Assert.assertNotNull(websocketUrl);
+
     // Validate the response.
     ValidationResult result = ValidationHelper.validate(capabilityStatement);
     Assert.assertTrue(result.isSuccessful());
@@ -80,6 +90,14 @@ public class MetadataTest {
     String body = mvcresult.getResponse().getContentAsString();
     CapabilityStatement capabilityStatement = (CapabilityStatement) App.FHIR_CTX.newXmlParser().parseResource(body);
     Assert.assertNotNull(capabilityStatement);
+
+    // Test the websocket extension is included
+    StringType websocketUrl = null;
+    for (Extension ext : capabilityStatement.getExtension()) {
+      if (ext.getUrl().equals("http://hl7.org/fhir/StructureDefinition/capabilitystatement-websocket"))
+        websocketUrl = (StringType) ext.getValue();
+    }
+    Assert.assertNotNull(websocketUrl);
 
     // Validate the response.
     ValidationResult result = ValidationHelper.validate(capabilityStatement);

--- a/src/test/java/org/hl7/davinci/priorauth/SubscriptionEndpointTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/SubscriptionEndpointTest.java
@@ -8,9 +8,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.hl7.fhir.dstu3.model.codesystems.IssueSeverity;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Subscription;
 import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r4.model.Subscription.SubscriptionStatus;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -146,6 +148,10 @@ public class SubscriptionEndpointTest {
         Subscription subscriptionResponse = (Subscription) App.FHIR_CTX.newJsonParser().parseResource(responseBody);
         Assert.assertNotNull(subscriptionResponse);
 
+        // Test the Subscription has an ID and the status is active
+        Assert.assertNotNull(FhirUtils.getIdFromResource(subscriptionResponse));
+        Assert.assertEquals(SubscriptionStatus.ACTIVE, subscriptionResponse.getStatus());
+
         // Test that the database contains the proper entries
         Map<String, Object> constraintMap = new HashMap<String, Object>();
         constraintMap.put("claimResponseId", "pended");
@@ -254,5 +260,126 @@ public class SubscriptionEndpointTest {
         // Validate the response
         ValidationResult result = ValidationHelper.validate(subscriptionResponse);
         Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void searchSubscriptions() throws Exception {
+        // Test that we can GET /fhir/Subscription.
+        DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+        MockMvc mockMvc = builder.build();
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/Subscription?patient.identifier=pat013").header("Accept", "application/fhir+json")
+                .header("Access-Control-Request-Method", "GET").header("Origin", "http://localhost:" + port);
+
+        // Test the response has CORS headers and returned status 200
+        MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
+
+        // Test the response is a JSON Bundle
+        String body = mvcresult.getResponse().getContentAsString();
+        Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+        Assert.assertNotNull(bundle);
+
+        // Validate the response.
+        ValidationResult result = ValidationHelper.validate(bundle);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void searchSubscriptionsXml() throws Exception {
+        // Test that we can GET /fhir/Subscription.
+        DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+        MockMvc mockMvc = builder.build();
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/Subscription?patient.identifier=pat013").header("Accept", "application/fhir+xml")
+                .header("Access-Control-Request-Method", "GET").header("Origin", "http://localhost:" + port);
+
+        // Test the response has CORS headers and returned status 200
+        MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
+
+        // Test the response is a XML Bundle
+        String body = mvcresult.getResponse().getContentAsString();
+        Bundle bundle = (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
+        Assert.assertNotNull(bundle);
+
+        // Validate the response.
+        ValidationResult result = ValidationHelper.validate(bundle);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void subscriptionExists() {
+        Map<String, Object> constraintMap = new HashMap<String, Object>();
+        constraintMap.put("id", "minimal");
+        constraintMap.put("patient", "pat013");
+        Subscription subscription = (Subscription) App.getDB().read(Table.SUBSCRIPTION, constraintMap);
+        Assert.assertNotNull(subscription);
+    }
+
+    @Test
+    public void getSubscription() throws Exception {
+        // Test that we can get fhir/Subscription/minimal
+        DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+        MockMvc mockMvc = builder.build();
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/Subscription?identifier=pended&patient.identifier=pat013")
+                .header("Accept", "application/fhir+json").header("Access-Control-Request-Method", "GET")
+                .header("Origin", "http://localhost:" + port);
+
+        // Test the response has CORS headers and returned status 200
+        MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
+
+        // Test the response is a JSON Bundle
+        String body = mvcresult.getResponse().getContentAsString();
+        Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+        Assert.assertNotNull(bundle);
+
+        // Validate the response.
+        ValidationResult result = ValidationHelper.validate(bundle);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void getSubscriptionXml() throws Exception {
+        // Test that we can get fhir/Subscription/minimal
+        DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+        MockMvc mockMvc = builder.build();
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/Subscription?identifier=pended&patient.identifier=pat013")
+                .header("Accept", "application/fhir+xml").header("Access-Control-Request-Method", "GET")
+                .header("Origin", "http://localhost:" + port);
+
+        // Test the response has CORS headers and returned status 200
+        MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
+
+        // Test the response is a XML Bundle
+        String body = mvcresult.getResponse().getContentAsString();
+        Bundle bundle = (Bundle) App.FHIR_CTX.newXmlParser().parseResource(body);
+        Assert.assertNotNull(bundle);
+
+        // Validate the response.
+        ValidationResult result = ValidationHelper.validate(bundle);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void getSubscriptionThatDoesNotExist() throws Exception {
+        // Test that non-existent Subscription returns 200 and an empty bundle
+        DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+        MockMvc mockMvc = builder.build();
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/Subscription?identifier=ClaimResponseThatDoesNotExist&patient.identifier=45")
+                .header("Accept", "application/fhir+json").header("Access-Control-Request-Method", "GET")
+                .header("Origin", "http://localhost:" + port);
+
+        // Test the response has CORS headers and returned status 200
+        MvcResult mvcresult = mockMvc.perform(requestBuilder).andExpect(ok).andExpect(cors).andReturn();
+
+        // Test the response is a JSON Bundle
+        String body = mvcresult.getResponse().getContentAsString();
+        Bundle bundle = (Bundle) App.FHIR_CTX.newJsonParser().parseResource(body);
+        Assert.assertNotNull(bundle);
+
+        // Validate the bundle is empty
+        Assert.assertEquals(0, bundle.getTotal());
     }
 }

--- a/src/test/resources/subscription-email.json
+++ b/src/test/resources/subscription-email.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Subscription",
-  "status": "active",
+  "status": "requested",
   "reason": "subscribe to updates for a pended ClaimResponse (priorauthorization)",
   "criteria": "identifier=granted&patient.identifier=pat013&status=active",
   "channel": {

--- a/src/test/resources/subscription-resthook.json
+++ b/src/test/resources/subscription-resthook.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Subscription",
-  "status": "active",
+  "status": "requested",
   "reason": "subscribe to updates for a pended ClaimResponse (priorauthorization)",
   "criteria": "identifier=pended&patient.identifier=pat013&status=active",
   "channel": {

--- a/src/test/resources/subscription-websocket.json
+++ b/src/test/resources/subscription-websocket.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Subscription",
-  "status": "active",
+  "status": "requested",
   "reason": "subscribe to updates for a pended ClaimResponse (priorauthorization)",
   "criteria": "identifier=granted&patient.identifier=pat013&status=active",
   "channel": {


### PR DESCRIPTION
Fixed a few HTTP REST issues with the server

1. Location header was being set incorrectly
2. Location header implies 3xx or 201 status (instead of 200). Updated $submit operation to return status 201 (created) as it makes more sense
3. On the topic of HTTP and RESTful servers GET requests should not have side effects. There fore expunge and populateDB should only be POST requests