### PR TITLE
Fix expunge operations when Subscription exists

### DIFF
--- a/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ExpungeOperation.java
@@ -32,11 +32,11 @@ public class ExpungeOperation {
     logger.info("POST /$expunge");
     if (App.debugMode) {
       // Cascading delete of everything...
+      App.getDB().delete(Table.SUBSCRIPTION);
       App.getDB().delete(Table.BUNDLE);
       App.getDB().delete(Table.CLAIM);
       App.getDB().delete(Table.CLAIM_ITEM);
       App.getDB().delete(Table.CLAIM_RESPONSE);
-      App.getDB().delete(Table.SUBSCRIPTION);
       return ResponseEntity.ok().body("Expunge success!");
     } else {
       logger.warning("ExpungeOperation::expungeDatabase:query disabled");


### PR DESCRIPTION
Due to the foreign key constraints placed on the Subscription table the expunge operation would not expunge the Claim and ClaimResponse table if there were subscriptions. The table was purposefully created to not cascade delete on Subscription.
Deleting the Subscription table first and then the others ensures there will be no foreign keys and the expunge operation deletes everything as expected.