### PR TITLE
Make reviewaction valueCode

### DIFF
--- a/src/main/java/org/hl7/davinci/priorauth/ClaimResponseFactory.java
+++ b/src/main/java/org/hl7/davinci/priorauth/ClaimResponseFactory.java
@@ -15,7 +15,6 @@ import org.hl7.fhir.r4.model.Claim;
 import org.hl7.fhir.r4.model.ClaimResponse;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Reference;
@@ -81,7 +80,7 @@ public class ClaimResponseFactory {
         response.setId(id);
 
         response.addExtension(FhirUtils.REVIEW_ACTION_EXTENSION_URL,
-                FhirUtils.dispositionToReviewAction(responseDisposition).value());
+                FhirUtils.dispositionToReviewAction(responseDisposition).valueCode());
 
         Identifier identifier = new Identifier();
         identifier.setSystem(App.getBaseUrl());
@@ -235,9 +234,7 @@ public class ClaimResponseFactory {
         } else if (action == ReviewAction.DENIED || action == ReviewAction.PENDED)
             itemComponent.addExtension(FhirUtils.REVIEW_ACTION_REASON_EXTENSION_URL, new StringType("X"));
 
-        Extension reviewActionExtension = new Extension(FhirUtils.REVIEW_ACTION_EXTENSION_URL);
-        reviewActionExtension.setValue(action.value());
-        itemComponent.addExtension(reviewActionExtension);
+        itemComponent.addExtension(FhirUtils.REVIEW_ACTION_EXTENSION_URL, action.valueCode());
 
         return itemComponent;
     }

--- a/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
+++ b/src/main/java/org/hl7/davinci/priorauth/FhirUtils.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Claim;
 import org.hl7.fhir.r4.model.ClaimResponse;
+import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.OperationOutcome;
@@ -18,7 +19,6 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Claim.ClaimStatus;
 import org.hl7.fhir.r4.model.Claim.RelatedClaimComponent;
@@ -75,17 +75,17 @@ public class FhirUtils {
       this.value = value;
     }
 
-    public StringType value() {
-      return new StringType(this.value);
+    public CodeType valueCode() {
+      return new CodeType(this.value);
     }
 
-    public String asStringValue() {
+    public String value() {
       return this.value;
     }
 
     public static ReviewAction fromString(String value) {
       for (ReviewAction reviewAction : ReviewAction.values()) {
-        if (reviewAction.asStringValue().equals(value))
+        if (reviewAction.value().equals(value))
           return reviewAction;
       }
 
@@ -326,7 +326,7 @@ public class FhirUtils {
     String outcome = App.getDB().readString(Table.CLAIM_RESPONSE, Collections.singletonMap("claimId", id), "outcome");
     logger.fine("FhirUtils::isPended:Outcome " + outcome);
 
-    return outcome != null ? outcome.equals(ReviewAction.PENDED.asStringValue()) : false;
+    return outcome != null ? outcome.equals(ReviewAction.PENDED.value()) : false;
   }
 
   /**

--- a/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
+++ b/src/main/java/org/hl7/davinci/priorauth/SubscriptionEndpoint.java
@@ -190,7 +190,7 @@ public class SubscriptionEndpoint {
         String outcome = App.getDB().readString(Table.CLAIM_RESPONSE, Collections.singletonMap("id", claimResponseId),
                 "outcome");
         logger.info("SubscriptionEndpoint::Outcome for desired resource is: " + outcome);
-        if (!outcome.equals(FhirUtils.ReviewAction.PENDED.asStringValue()))
+        if (!outcome.equals(FhirUtils.ReviewAction.PENDED.value()))
             return null;
 
         // Add to db

--- a/src/test/java/org/hl7/davinci/priorauth/ClaimResponseFactoryTest.java
+++ b/src/test/java/org/hl7/davinci/priorauth/ClaimResponseFactoryTest.java
@@ -15,7 +15,6 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Claim;
 import org.hl7.fhir.r4.model.ClaimResponse;
 import org.hl7.fhir.r4.model.ClaimResponse.ClaimResponseStatus;
-import org.hl7.fhir.r4.model.ClaimResponse.ItemComponent;
 import org.hl7.fhir.r4.model.ClaimResponse.RemittanceOutcome;
 import org.junit.After;
 import org.junit.Assert;
@@ -124,7 +123,7 @@ public class ClaimResponseFactoryTest {
         Assert.assertNotNull(claimResponse);
         Assert.assertEquals(status, claimResponse.getStatus());
         Assert.assertEquals(disposition.value(), claimResponse.getDisposition());
-        Assert.assertEquals(reviewAction.asStringValue(),
+        Assert.assertEquals(reviewAction.value(),
                 claimResponse.getExtensionByUrl(FhirUtils.REVIEW_ACTION_EXTENSION_URL).getValue().primitiveValue());
         Assert.assertTrue(claimResponse.hasIdentifier());
 


### PR DESCRIPTION
Updated so the reviewAction extension uses valueCode instead of valueString. This is handled by the extension class automatically so long as the type is `CodeType`. Cleaned up the enums to define the type in value methods if returning an extension of the `Type` class. The default `.value()` method is for the java `String` type only now.

I checked the DTR RI and this extension is not actually used there but you can check it is working by submitting a claim via postman and confirming the reviewAction extension (present both on `Claim` and `Claim.item`) has the properties `url` and `valueCode`.